### PR TITLE
Always allow spaces inside arrays

### DIFF
--- a/packages/eslint-config-humanmade/.eslintrc.yml
+++ b/packages/eslint-config-humanmade/.eslintrc.yml
@@ -15,8 +15,7 @@ rules:
   array-bracket-spacing:
   - error
   - always
-  - singleValue: false
-    objectsInArrays: false
+  - objectsInArrays: false
   block-spacing:
   - error
   brace-style:


### PR DESCRIPTION
Allow spaces inside brackets of array literals that contain a single element.

`"singleValue": false` makes an exception for `[1]` and similar, so removing it makes the spacing consistent. See [documentation](http://eslint.org/docs/rules/array-bracket-spacing).