### PR TITLE
Whitelist 1 level of indentation in `switch` cases.

### DIFF
--- a/packages/eslint-config-humanmade/.eslintrc.yml
+++ b/packages/eslint-config-humanmade/.eslintrc.yml
@@ -57,6 +57,7 @@ rules:
   indent:
   - error
   - tab
+  - SwitchCase: 1
   no-mixed-spaces-and-tabs:
   - error
   - smart-tabs


### PR DESCRIPTION
This code:
```
export default function cache( state = {}, action ) {
	switch ( action.type ) {
		case 'UPDATE_CACHE':
			return Object.assign( {}, state, action.payload );

		default:
			return state;
	}
}
```

 currently produces the following error:
```
  3:3  error  Expected indentation of 1 tab but found 2   indent
  4:4  error  Expected indentation of 2 tabs but found 3  indent
  6:3  error  Expected indentation of 1 tab but found 2   indent
  7:4  error  Expected indentation of 2 tabs but found 3  indent
```

To pass the linting, this would have to be written like this:
```
export default function cache( state = {}, action ) {
	switch ( action.type ) {
	case 'UPDATE_CACHE':
		return Object.assign( {}, state, action.payload );

	default:
		return state;
	}
}
```

This is because the `SwitchCase` indent level is not set.