### PR TITLE
incorrectly detects `function() use () {}`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: php:7.1
-    working_directory: ~
+    working_directory: /tmp/hm-cs
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ jobs:
       - image: php:7.1
     working_directory: /tmp/hm-cs
     steps:
+      - run:
+          name: Install Git
+          command: |
+            apt-get update
+            apt-get install -y git-all
       - checkout
       - run:
           name: Install Composer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: php:7.1
+    working_directory: /tmp
+    steps:
+      - checkout
+      - run:
+          name: Install Composer
+          command: |
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+            php -r "copy('https://composer.github.io/installer.sig', 'composer-setup.sig');" && \
+            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+            php composer-setup.php && \
+            php -r "unlink('composer-setup.php');"
+      - run:
+          name: Install PHPCS
+          command: |
+            git clone git@github.com:squizlabs/PHP_CodeSniffer
+            cd PHP_CodeSniffer
+            git checkout 2.8.1
+            php /tmp/composer.phar install
+            scripts/phpcs --set-config
+      - run: php composer.phar install
+      - run:
+          name: Tests
+          command: |
+            cd PHP_CodeSniffer
+            vendor/bin/phpunit --filter HM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     docker:
       - image: php:7.1
-    working_directory: /tmp
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
             cd PHP_CodeSniffer
             git checkout 2.8.1
             php /tmp/composer.phar install
-            scripts/phpcs --set-config
+            scripts/phpcs --set-config installed_paths
       - run: php composer.phar install
       - run:
-          name: Tests
+          name: Run Tests
           command: |
             cd PHP_CodeSniffer
             vendor/bin/phpunit --filter HM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,26 +10,30 @@ jobs:
           command: |
             apt-get update
             apt-get install -y git-all
-      - checkout
       - run:
           name: Install Composer
           command: |
+            mkdir /tmp/composer
+            cd /tmp/composer
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
             php -r "copy('https://composer.github.io/installer.sig', 'composer-setup.sig');" && \
             php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
             php composer-setup.php && \
             php -r "unlink('composer-setup.php');"
+      - checkout
       - run:
           name: Install PHPCS
           command: |
-            git clone git@github.com:squizlabs/PHP_CodeSniffer
-            cd PHP_CodeSniffer
+            git clone git@github.com:squizlabs/PHP_CodeSniffer /tmp/phpcs
+            cd /tmp/phpcs
             git checkout 2.8.1
-            php /tmp/composer.phar install
-            scripts/phpcs --set-config installed_paths
-      - run: php composer.phar install
+            php /tmp/composer/composer.phar install
+            scripts/phpcs --set-config installed_paths /tmp/hm-cs
+      - run:
+          name: Composer Install
+          command: php /tmp/composer/composer.phar install
       - run:
           name: Run Tests
           command: |
-            cd PHP_CodeSniffer
+            cd /tmp/phpcs
             vendor/bin/phpunit --filter HM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             cd /tmp/phpcs
             git checkout 2.8.1
             php /tmp/composer/composer.phar install
-            scripts/phpcs --set-config installed_paths /tmp/hm-cs
+            scripts/phpcs --config-set installed_paths /tmp/hm-cs
       - run:
           name: Composer Install
           command: php /tmp/composer/composer.phar install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: php:7.1
+    working_directory: ~
     steps:
       - checkout
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore composer things.
 vendor/
 composer.lock
+.idea/

--- a/HM/Sniffs/Layout/OrderSniff.php
+++ b/HM/Sniffs/Layout/OrderSniff.php
@@ -46,6 +46,11 @@ class OrderSniff implements PHP_CodeSniffer_Sniff {
 			}
 
 			$next_token = $tokens[ $next_pos ];
+			
+			// Ignore use in nested functions.
+			if ( 'use' === $next_token['content'] && isset( $next_token['nested_parenthesis'] ) ) {
+				return;
+			}
 
 			// Must be current or higher.
 			$next_type_score = $look_for[ $next_token['code'] ];

--- a/HM/Sniffs/Layout/OrderSniff.php
+++ b/HM/Sniffs/Layout/OrderSniff.php
@@ -48,7 +48,7 @@ class OrderSniff implements PHP_CodeSniffer_Sniff {
 			$next_token = $tokens[ $next_pos ];
 			
 			// Ignore use in nested functions.
-			if ( 'use' === $next_token['content'] && isset( $next_token['nested_parenthesis'] ) ) {
+			if ( $next_token['type'] === 'T_USE' && $next_token['level'] > 0 ) {
 				return;
 			}
 

--- a/HM/Tests/Layout/OrderUnitTest.inc
+++ b/HM/Tests/Layout/OrderUnitTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+use Exception;
+
+namespace HM\Coding\Standards\Tests;
+
+require 'include1.php';
+require_once 'include2.php';
+
+const SOME_CONSTANT = '😎';
+
+function code_starts_now() {
+
+	$var = '🧀';
+
+	$func = function() use ( $var ) {
+		return $var . '😤';
+	};
+
+	return $func();
+}
+
+include 'include3.php';
+include_once 'include4.php';

--- a/HM/Tests/Layout/OrderUnitTest.inc
+++ b/HM/Tests/Layout/OrderUnitTest.inc
@@ -2,8 +2,8 @@
 
 namespace HM\Coding\Standards\Tests;
 
-require 'include1.php';
-require_once 'include2.php';
+require 'include3.php';
+require_once 'include4.php';
 
 const SOME_CONSTANT = '😎';
 
@@ -17,6 +17,3 @@ function code_starts_now() {
 
 	return $func();
 }
-
-include 'include3.php';
-include_once 'include4.php';

--- a/HM/Tests/Layout/OrderUnitTest.inc
+++ b/HM/Tests/Layout/OrderUnitTest.inc
@@ -1,7 +1,5 @@
 <?php
 
-use Exception;
-
 namespace HM\Coding\Standards\Tests;
 
 require 'include1.php';

--- a/HM/Tests/Layout/OrderUnitTest.php
+++ b/HM/Tests/Layout/OrderUnitTest.php
@@ -1,10 +1,6 @@
 <?php
 
-namespace HM\Tests\Layout;
-
-use AbstractSniffUnitTest;
-
-class OrderUnitTest extends AbstractSniffUnitTest {
+class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -12,23 +8,18 @@ class OrderUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
-			3 => 1,
-			5 => 1,
-			7 => 1,
-			8 => 1,
-			12 => 1,
-			23 => 1,
-			24 => 1,
-		);
+		return [
+			1  => 1,
+		];
 	}
+
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/HM/Tests/Layout/OrderUnitTest.php
+++ b/HM/Tests/Layout/OrderUnitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace HM\Tests\Layout;
+
+use AbstractSniffUnitTest;
+
+class OrderUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			5 => 1,
+			7 => 1,
+			8 => 1,
+			12 => 1,
+			23 => 1,
+			24 => 1,
+		);
+	}
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,6 @@
 		"wp-coding-standards/wpcs": "^0.10.0",
 		"fig-r/psr2r-sniffer": "^0.3.1"
 	},
-	"require-dev": {
-		"phpunit/phpunit": "^5.7"
-	},
 	"scripts": {
 		"post-install-cmd": "phpcs --config-set installed_paths $(pwd)",
 		"post-update-cmd" : "phpcs --config-set installed_paths $(pwd)"

--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,12 @@
 	"require": {
 		"wp-coding-standards/wpcs": "^0.10.0",
 		"fig-r/psr2r-sniffer": "^0.3.1"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7"
+	},
+	"scripts": {
+		"post-install-cmd": "phpcs --config-set installed_paths $(pwd)",
+		"post-update-cmd" : "phpcs --config-set installed_paths $(pwd)"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -118,3 +118,64 @@ The phpcs standard is based upon the `WordPress-VIP` standard from [WordPress Co
 phpcs also includes ESLint checking based upon the `eslint:recommended` standard (checks from [this page](http://eslint.org/docs/rules/) marked with a check mark), with [customisation and additions](.eslintrc.yml) to match our style guide.
 
 **Note:** ESLint checks are mapped from ESLint codes to phpcs codes by prefixing with `HM.Debug.ESLint`. e.g. the `no-unused-vars` ESLint code becomes `HM.Debug.ESLint.no-unused-vars`. You need to use the phpcs code when excluding specific rules.
+
+## Testing
+
+### Running tests
+
+To run the tests locally you need a checkout of PHP Code Sniffer, any other
+type of install that isn't v3 or higher will not have the tests included.
+
+```bash
+git clone git@github.com:squizlabs/PHP_CodeSniffer
+cd PHP_CodeSniffer
+git checkout 2.8.1
+composer install
+scripts/phpcs --config-set installed_paths /path/to/this/repo
+vendor/bin/phpunit --filter HM
+```
+
+### Writing tests
+
+To add tests you should mirror the directory structure of the sniffs. For example a test
+for `HM/Sniffs/Layout/OrderSniff.php` would require the following files:
+
+```
+HM/Tests/Layout/OrderUnitTest.php # Unit test code
+HM/Tests/Layout/OrderUnitTest.inc # Code to be tested
+```
+
+A basic unit test class looks like the following:
+
+```php
+<?php
+
+/**
+ * Class name must follow the directory structure to be autoloaded correctly.
+ * 
+ * **NO NAMESPACES!!**
+ */
+class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [
+			1  => 1, // line 1 expects 1 error
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}
+```

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -2,7 +2,7 @@
 <ruleset name="HM">
 	<description>Loader for the main HM sniffer.</description>
 
-	<config name="eslint_path" value="vendor/humanmade/coding-standards/node_modules/.bin/eslint" />
+	<config name="eslint_path" value="node_modules/.bin/eslint" />
 	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer" />
-	<rule ref="vendor/humanmade/coding-standards/HM/ruleset.xml" />
+	<rule ref="HM/ruleset.xml" />
 </ruleset>


### PR DESCRIPTION
If you have a nested or lambda function using the `use` keyword this sniff picks it up and flags it as an issue.

In the above scenario the token will have `nested_parenthesis` set so this PR just adds a check for that and skips the token.