### PR TITLE
Fix order sniff, add tests

### DIFF
--- a/HM/Sniffs/Layout/OrderSniff.php
+++ b/HM/Sniffs/Layout/OrderSniff.php
@@ -47,6 +47,11 @@ class OrderSniff implements PHP_CodeSniffer_Sniff {
 
 			$next_token = $tokens[ $next_pos ];
 
+			// Ignore nested `use` eg. in lambda functions.
+			if ( $next_token['type'] === 'T_USE' && $next_token['level'] > 0 ) {
+				return;
+			}
+
 			// Must be current or higher.
 			$next_type_score = $look_for[ $next_token['code'] ];
 			if ( $next_type_score < $current_score ) {

--- a/HM/Tests/Layout/OrderUnitTest.inc
+++ b/HM/Tests/Layout/OrderUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+require 'include3.php';
+require_once 'include4.php';
+
+const SOME_CONSTANT = '😎';
+
+function code_starts_now() {
+
+	$var = '🧀';
+
+	$func = function() use ( $var ) {
+		return $var . '😤';
+	};
+
+	return $func();
+}

--- a/HM/Tests/Layout/OrderUnitTest.php
+++ b/HM/Tests/Layout/OrderUnitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [
+			1  => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}


### PR DESCRIPTION
The order sniff was incorrectly picking up the use keyword in nested lambda functions. This fixes it and adds a unit test for the sniff.

cc @rmccue