### PR TITLE
Adding travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+php:
+  - '5.3'
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - hhvm
+
+install:
+  - composer install
+  - npm install
+
+before_script:
+  - |
+    git clone -b 2.8.1 git@github.com:squizlabs/PHP_CodeSniffer /tmp/phpcs
+    composer install
+    scripts/phpcs --config-set installed_paths $TRAVIS_BUILD_DIR
+
+script:
+  - /tmp/phpcs/vendor/bin/phpunit --filter HM
+
+cache:
+  directories:
+    - /tmp/phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - npm install
 
 before_script:
-  - git clone -b 2.8.1 git@github.com:squizlabs/PHP_CodeSniffer /tmp/phpcs
+  - git clone -b 2.8.1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
   - cd /tmp/phpcs && composer install
   - /tmp/phpcs/scripts/phpcs --config-set installed_paths $TRAVIS_BUILD_DIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 php:
-  - '5.3'
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
@@ -13,10 +10,9 @@ install:
   - npm install
 
 before_script:
-  - |
-    git clone -b 2.8.1 git@github.com:squizlabs/PHP_CodeSniffer /tmp/phpcs
-    composer install
-    scripts/phpcs --config-set installed_paths $TRAVIS_BUILD_DIR
+  - git clone -b 2.8.1 git@github.com:squizlabs/PHP_CodeSniffer /tmp/phpcs
+  - cd /tmp/phpcs && composer install
+  - /tmp/phpcs/scripts/phpcs --config-set installed_paths $TRAVIS_BUILD_DIR
 
 script:
   - /tmp/phpcs/vendor/bin/phpunit --filter HM

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - npm install
 
 before_script:
-  - git clone -b 2.8.1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
+  - if [[ ! -d /tmp/phpcs ]]; then git clone -b 2.8.1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs; fi
   - cd /tmp/phpcs && composer install
   - /tmp/phpcs/scripts/phpcs --config-set installed_paths $TRAVIS_BUILD_DIR
 
@@ -19,4 +19,6 @@ script:
 
 cache:
   directories:
+    - $HOME/.composer/cache/files
+    - $HOME/.npm
     - /tmp/phpcs

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@
 		<td align="center" width="30%">
 			<a href="https://packagist.org/packages/humanmade/coding-standards"><img src="https://img.shields.io/packagist/v/humanmade/coding-standards.svg" /></a>
 			<a href="https://www.npmjs.com/package/eslint-config-humanmade"><img src="https://img.shields.io/npm/v/eslint-config-humanmade.svg" /></a>
+			<img src="https://travis-ci.org/humanmade/coding-standards.svg?branch=master" alt="Build Status" />
 		</td>
 	</tr>
 	<tr>
@@ -118,3 +119,65 @@ The phpcs standard is based upon the `WordPress-VIP` standard from [WordPress Co
 phpcs also includes ESLint checking based upon the `eslint:recommended` standard (checks from [this page](http://eslint.org/docs/rules/) marked with a check mark), with [customisation and additions](.eslintrc.yml) to match our style guide.
 
 **Note:** ESLint checks are mapped from ESLint codes to phpcs codes by prefixing with `HM.Debug.ESLint`. e.g. the `no-unused-vars` ESLint code becomes `HM.Debug.ESLint.no-unused-vars`. You need to use the phpcs code when excluding specific rules.
+
+## Testing
+
+### Running tests
+
+To run the tests locally you need a checkout of PHP Code Sniffer, any other
+type of install that isn't v3 or higher will not have the tests included.
+
+```bash
+git clone -b 2.8.1 git@github.com:squizlabs/PHP_CodeSniffer
+cd PHP_CodeSniffer
+composer install
+scripts/phpcs --config-set installed_paths /path/to/this/repo
+vendor/bin/phpunit --filter HM
+```
+
+### Writing tests
+
+To add tests you should mirror the directory structure of the sniffs. For example a test
+for `HM/Sniffs/Layout/OrderSniff.php` would require the following files:
+
+```
+HM/Tests/Layout/OrderUnitTest.php # Unit test code
+HM/Tests/Layout/OrderUnitTest.inc # Code to be tested
+```
+
+Effectively you are replacing the suffix `Sniff.php` with `UnitTest.php`.
+
+A basic unit test class looks like the following:
+
+```php
+<?php
+
+/**
+ * Class name must follow the directory structure to be autoloaded correctly.
+ * 
+ * **NO NAMESPACES!!**
+ */
+class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [
+			1  => 1, // line 1 expects 1 error
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}
+```


### PR DESCRIPTION
OS projects should use travis for running tests. This is the basic test harness for running code sniffer tests.