### PR TITLE
Fix rule when runing on Windows

### DIFF
--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -43,12 +43,12 @@ class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
 
 		$full = $phpcsFile->getFileName();
 		$filename = basename( $full );
-		$directory = dirname( $full );			 
+		$directory = dirname( $full );
 
 		// Normalize the directory seperator accross operating systems
 		if ( DIRECTORY_SEPARATOR !== '/' ) {
 			$directory = str_replace( DIRECTORY_SEPARATOR, '/', $directory );
-		}		
+		}
 
 		if ( $filename === 'plugin.php' || $filename === 'functions.php' ) {
 			// Ignore the main file.

--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -44,6 +44,11 @@ class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
 		$full = $phpcsFile->getFileName();
 		$filename = basename( $full );
 		$directory = dirname( $full );
+		
+		// Normalize the directory seperator accross operating systems
+		if ( strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN' ) {
+			$directory = str_replace( '\\', '/', $directory );
+		}		
 
 		if ( $filename === 'plugin.php' || $filename === 'functions.php' ) {
 			// Ignore the main file.
@@ -64,7 +69,7 @@ class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		$namespace_parts = explode( '\\', $namespace );
-		$directory_parts = explode( DIRECTORY_SEPARATOR, trim( $after_inc, DIRECTORY_SEPARATOR ) );
+		$directory_parts = explode( '/', trim( $after_inc, '/' ) );
 
 		// Check that the path matches the namespace, allowing parts to be dropped.
 		while ( ! empty( $directory_parts ) ) {

--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -43,11 +43,11 @@ class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
 
 		$full = $phpcsFile->getFileName();
 		$filename = basename( $full );
-		$directory = dirname( $full );
-		
+		$directory = dirname( $full );			 
+
 		// Normalize the directory seperator accross operating systems
-		if ( strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN' ) {
-			$directory = str_replace( '\\', '/', $directory );
+		if ( DIRECTORY_SEPARATOR !== '/' ) {
+			$directory = str_replace( DIRECTORY_SEPARATOR, '/', $directory );
 		}		
 
 		if ( $filename === 'plugin.php' || $filename === 'functions.php' ) {


### PR DESCRIPTION
`DIRECTORY_SEPARATOR` is equal to `\` on Windows, but the code uses a hard coded `/inc` to do its checks.

This fix normalizes `$directory` when running on Windows.