### PR TITLE
Require space after negation("!") operator

### DIFF
--- a/packages/eslint-config-humanmade/.eslintrc.yml
+++ b/packages/eslint-config-humanmade/.eslintrc.yml
@@ -75,6 +75,8 @@ rules:
   - error
   - words: true
     nonwords: false
+    overrides:
+      "!": true
   no-multiple-empty-lines:
   - error
   - max: 1


### PR DESCRIPTION
Re-fixes #16.