### PR TITLE
Require spaces for objects inside objects

### DIFF
--- a/packages/eslint-config-humanmade/.eslintrc.yml
+++ b/packages/eslint-config-humanmade/.eslintrc.yml
@@ -86,7 +86,6 @@ rules:
   object-curly-spacing:
   - error
   - always
-  - objectsInObjects: false
   arrow-parens:
   - error
   - as-needed


### PR DESCRIPTION
This was meant to allow this:
```js
var x = { 'y': {
    // ...
}};
```

But as it turns out, it's utterly useless, and that was a terrible idea anyway.

Fixes #18.