### PR TITLE
Remove VIP rule for adminbar

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -19,6 +19,7 @@
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
 		<exclude name="WordPress.VIP.DirectDatabaseQuery" />
 		<exclude name="WordPress.XSS.EscapeOutput" />
+		<exclude name="WordPress.VIP.AdminBarRemoval" />
 
 		<!--
 		OK, real talk right now. Yoda conditions are ridiculous.


### PR DESCRIPTION
I also don't like most of the VIP rules so personally think we would be better to select specific ones we wanted rather than importing all theirs.