### PR TITLE
Exclude space checks from JS files

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -9,6 +9,11 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>*.min.js</exclude-pattern>
 
+	<!-- Exclude rules from the JS parser. -->
+	<rule ref="WordPress.WhiteSpace.OperatorSpacing">
+		<exclude-pattern>*.js</exclude-pattern>
+	</rule>
+
 	<!-- Include everything in the VIP standard... -->
 	<rule ref="WordPress-VIP">
 		<!-- ...Except for VIP-specific things -->


### PR DESCRIPTION
This avoids the JS-in-PHP parser thinking that `<Component>` is actually comparison operators and complaining endlessly about it.