### PR TITLE
Update phpcs to v3

### DIFF
--- a/HM/Sniffs/Classes/OnlyClassInFileSniff.php
+++ b/HM/Sniffs/Classes/OnlyClassInFileSniff.php
@@ -2,14 +2,13 @@
 
 namespace HM\Sniffs\Classes;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check classes are by themselves.
  */
-class OnlyClassInFileSniff implements PHP_CodeSniffer_Sniff {
+class OnlyClassInFileSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -28,7 +27,7 @@ class OnlyClassInFileSniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$error = 'Files should only contain a single class, and no other declarations. First class was defined on line %s, and a %s was found on line %s.';
 
 		$tokens = $phpcsFile->getTokens();

--- a/HM/Sniffs/Debug/ESLintSniff.php
+++ b/HM/Sniffs/Debug/ESLintSniff.php
@@ -2,14 +2,14 @@
 
 namespace HM\Sniffs\Debug;
 
-use PHP_CodeSniffer;
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Run ESLint on the file.
  */
-class ESLintSniff implements PHP_CodeSniffer_Sniff {
+class ESLintSniff implements Sniff {
 	/**
 	 * Path to default configuration.
 	 */
@@ -41,16 +41,16 @@ class ESLintSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-	 * @param int                  $stackPtr  The position in the stack where
+	 * @param File $phpcsFile The file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where
 	 *                                        the token was found.
 	 *
 	 * @return void
 	 * @throws PHP_CodeSniffer_Exception If jslint.js could not be run
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$filename = $phpcsFile->getFilename();
-		$eslint_path = PHP_CodeSniffer::getConfigData( 'eslint_path' );
+		$eslint_path = Config::getConfigData( 'eslint_path' );
 		if ( $eslint_path === null ) {
 			return;
 		}

--- a/HM/Sniffs/Files/ClassFileNameSniff.php
+++ b/HM/Sniffs/Files/ClassFileNameSniff.php
@@ -1,13 +1,13 @@
 <?php
 namespace HM\Sniffs\Files;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Filenames with classes must start with class- and be the class name.
  */
-class ClassFileNameSniff implements PHP_CodeSniffer_Sniff {
+class ClassFileNameSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -20,13 +20,13 @@ class ClassFileNameSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the
+	 *                        stack passed in $tokens.
 	 *
 	 * @return int
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$namespace_ptr = $phpcsFile->findNext(T_NAMESPACE, 0);
 		if ( ! $namespace_ptr ) {

--- a/HM/Sniffs/Files/FunctionFileNameSniff.php
+++ b/HM/Sniffs/Files/FunctionFileNameSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Files;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check for namespaced functions are in `namespace.php`.
  */
-class FunctionFileNameSniff implements PHP_CodeSniffer_Sniff {
+class FunctionFileNameSniff implements Sniff {
 	public function register() {
 		return array( T_FUNCTION );
 	}
 
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		if ( $tokens[ $stackPtr ]['level'] !== 0 ) {
 			// Ignore methods.

--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -1,13 +1,13 @@
 <?php
 namespace HM\Sniffs\Files;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Namespaced things must be in directories matching the namespace.
  */
-class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
+class NamespaceDirectoryNameSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -20,13 +20,13 @@ class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the
+	 *                        stack passed in $tokens.
 	 *
 	 * @return int
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$namespace = '';
 

--- a/HM/Sniffs/Functions/NamespacedFunctionsSniff.php
+++ b/HM/Sniffs/Functions/NamespacedFunctionsSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Functions;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check for namespaces for functions.
  */
-class NamespacedFunctionsSniff implements PHP_CodeSniffer_Sniff {
+class NamespacedFunctionsSniff implements Sniff {
 	public function register() {
 		return array( T_FUNCTION );
 	}
 
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		if (isset($tokens[$stackPtr]['scope_closer']) === false) {
 			return;

--- a/HM/Sniffs/Layout/OrderSniff.php
+++ b/HM/Sniffs/Layout/OrderSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Layout;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check order of declarations (namespace, use, const, code).
  */
-class OrderSniff implements PHP_CodeSniffer_Sniff {
+class OrderSniff implements Sniff {
 	public function register() {
 		return array( T_OPEN_TAG );
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		// Things we can look for:

--- a/HM/Sniffs/Namespaces/NoLeadingSlashOnUseSniff.php
+++ b/HM/Sniffs/Namespaces/NoLeadingSlashOnUseSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Namespaces;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check `use` class isn't prefixed with `\`
  */
-class NoLeadingSlashOnUseSniff implements PHP_CodeSniffer_Sniff {
+class NoLeadingSlashOnUseSniff implements Sniff {
 	public function register() {
 		return array( T_USE );
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$look_for = [ T_STRING, T_NS_SEPARATOR ];
 		$next = $phpcsFile->findNext( $look_for, $stackPtr );

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0",
 	"require": {
 		"wp-coding-standards/wpcs": "^0.13.1",
-		"fig-r/psr2r-sniffer": "^0.4.1"
+		"fig-r/psr2r-sniffer": "dev-master",
+		"squizlabs/php_codesniffer": "^3.1"
 	}
 }


### PR DESCRIPTION
This gets us a bunch o' new stuff, including:

* Parallel checks with `--parallel=10`
* Caching between runs with `--cache`
* `--report=code` to show the errored line in context
* `-m` to suppress error message gathering to save memory
* Autodetection of phpcs files
* ES6 tokenisation
* Progress with `-p`

[All changes](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.0.0).