### PR TITLE
Add tests for our phpcs sniffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,5 @@ install:
   - composer install
   - npm install
 
-before_script:
-  - if [[ ! -d /tmp/phpcs ]]; then git clone -b 2.8.1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs; fi
-  - cd /tmp/phpcs && composer install
-  - /tmp/phpcs/scripts/phpcs --config-set installed_paths $TRAVIS_BUILD_DIR
-
 script:
-  - /tmp/phpcs/vendor/bin/phpunit --filter HM
-
-cache:
-  directories:
-    - $HOME/.composer/cache/files
-    - $HOME/.npm
-    - /tmp/phpcs
+  - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
-  - hhvm
 
 install:
   - composer install

--- a/HM/Sniffs/Classes/OnlyClassInFileSniff.php
+++ b/HM/Sniffs/Classes/OnlyClassInFileSniff.php
@@ -2,14 +2,13 @@
 
 namespace HM\Sniffs\Classes;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check classes are by themselves.
  */
-class OnlyClassInFileSniff implements PHP_CodeSniffer_Sniff {
+class OnlyClassInFileSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -28,7 +27,7 @@ class OnlyClassInFileSniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$error = 'Files should only contain a single class, and no other declarations. First class was defined on line %s, and a %s was found on line %s.';
 
 		$tokens = $phpcsFile->getTokens();

--- a/HM/Sniffs/Debug/ESLintSniff.php
+++ b/HM/Sniffs/Debug/ESLintSniff.php
@@ -2,14 +2,14 @@
 
 namespace HM\Sniffs\Debug;
 
-use PHP_CodeSniffer;
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Run ESLint on the file.
  */
-class ESLintSniff implements PHP_CodeSniffer_Sniff {
+class ESLintSniff implements Sniff {
 	/**
 	 * Path to default configuration.
 	 */
@@ -41,16 +41,16 @@ class ESLintSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-	 * @param int                  $stackPtr  The position in the stack where
+	 * @param File $phpcsFile The file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where
 	 *                                        the token was found.
 	 *
 	 * @return void
 	 * @throws PHP_CodeSniffer_Exception If jslint.js could not be run
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$filename = $phpcsFile->getFilename();
-		$eslint_path = PHP_CodeSniffer::getConfigData( 'eslint_path' );
+		$eslint_path = Config::getConfigData( 'eslint_path' );
 		if ( $eslint_path === null ) {
 			return;
 		}

--- a/HM/Sniffs/Files/ClassFileNameSniff.php
+++ b/HM/Sniffs/Files/ClassFileNameSniff.php
@@ -1,13 +1,13 @@
 <?php
 namespace HM\Sniffs\Files;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Filenames with classes must start with class- and be the class name.
  */
-class ClassFileNameSniff implements PHP_CodeSniffer_Sniff {
+class ClassFileNameSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -20,13 +20,13 @@ class ClassFileNameSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the
+	 *                        stack passed in $tokens.
 	 *
 	 * @return int
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$namespace_ptr = $phpcsFile->findNext(T_NAMESPACE, 0);
 		if ( ! $namespace_ptr ) {

--- a/HM/Sniffs/Files/FunctionFileNameSniff.php
+++ b/HM/Sniffs/Files/FunctionFileNameSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Files;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check for namespaced functions are in `namespace.php`.
  */
-class FunctionFileNameSniff implements PHP_CodeSniffer_Sniff {
+class FunctionFileNameSniff implements Sniff {
 	public function register() {
 		return array( T_FUNCTION );
 	}
 
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		if ( $tokens[ $stackPtr ]['level'] !== 0 ) {
 			// Ignore methods.

--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -1,13 +1,13 @@
 <?php
 namespace HM\Sniffs\Files;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Namespaced things must be in directories matching the namespace.
  */
-class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
+class NamespaceDirectoryNameSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -20,13 +20,13 @@ class NamespaceDirectoryNameSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the
+	 *                        stack passed in $tokens.
 	 *
 	 * @return int
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$namespace = '';
 

--- a/HM/Sniffs/Functions/NamespacedFunctionsSniff.php
+++ b/HM/Sniffs/Functions/NamespacedFunctionsSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Functions;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check for namespaces for functions.
  */
-class NamespacedFunctionsSniff implements PHP_CodeSniffer_Sniff {
+class NamespacedFunctionsSniff implements Sniff {
 	public function register() {
 		return array( T_FUNCTION );
 	}
 
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		if (isset($tokens[$stackPtr]['scope_closer']) === false) {
 			return;

--- a/HM/Sniffs/Layout/OrderSniff.php
+++ b/HM/Sniffs/Layout/OrderSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Layout;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check order of declarations (namespace, use, const, code).
  */
-class OrderSniff implements PHP_CodeSniffer_Sniff {
+class OrderSniff implements Sniff {
 	public function register() {
 		return array( T_OPEN_TAG );
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		// Things we can look for:

--- a/HM/Sniffs/Namespaces/NoLeadingSlashOnUseSniff.php
+++ b/HM/Sniffs/Namespaces/NoLeadingSlashOnUseSniff.php
@@ -1,18 +1,18 @@
 <?php
 namespace HM\Sniffs\Namespaces;
 
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to check `use` class isn't prefixed with `\`
  */
-class NoLeadingSlashOnUseSniff implements PHP_CodeSniffer_Sniff {
+class NoLeadingSlashOnUseSniff implements Sniff {
 	public function register() {
 		return array( T_USE );
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$look_for = [ T_STRING, T_NS_SEPARATOR ];
 		$next = $phpcsFile->findNext( $look_for, $stackPtr );

--- a/HM/Tests/Classes/OnlyClassInFileUnitTest.fail.class
+++ b/HM/Tests/Classes/OnlyClassInFileUnitTest.fail.class
@@ -1,0 +1,15 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Bar {
+	public function test() {
+		echo 'bar';
+	}
+}
+
+class Foo {
+	public function test() {
+		echo 'foo';
+	}
+}

--- a/HM/Tests/Classes/OnlyClassInFileUnitTest.fail.function
+++ b/HM/Tests/Classes/OnlyClassInFileUnitTest.fail.function
@@ -1,0 +1,13 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+function foo() {
+	echo 'foo';
+}
+
+class Bar {
+	public function test() {
+		echo 'bar';
+	}
+}

--- a/HM/Tests/Classes/OnlyClassInFileUnitTest.php
+++ b/HM/Tests/Classes/OnlyClassInFileUnitTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace HM\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class OnlyClassInFileUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		$file = func_get_arg( 0 );
+		list( $_, $type, $variant ) = explode( '.', $file, 3 );
+		if ( $type !== 'fail' ) {
+			return [];
+		}
+
+		return [
+			1 => 1,
+		];
+	}
+
+}

--- a/HM/Tests/Classes/OnlyClassInFileUnitTest.success.const
+++ b/HM/Tests/Classes/OnlyClassInFileUnitTest.success.const
@@ -1,0 +1,11 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+const FOO = 'foo';
+
+class Bar {
+	public function test() {
+		echo 'bar';
+	}
+}

--- a/HM/Tests/Files/ClassFileNameUnitTest.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace HM\Tests\Files;
+
+use DirectoryIterator;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ClassFileNameUnitTest extends AbstractSniffUnitTest {
+	/**
+	 * Get files to test against.
+	 *
+	 * Overridden from base to use the directory instead.
+	 */
+	protected function getTestFiles( $test_base_dir ) {
+		$test_base_dir = rtrim( $test_base_dir, '.' );
+		$test_files = [];
+
+		$di = new DirectoryIterator( $test_base_dir );
+
+		foreach ( $di as $file ) {
+			if ( $file->isDot() ) {
+				continue;
+			}
+
+			$test_files[] = $file->getPathname();
+		}
+
+		// Put them in order.
+		sort( $test_files );
+
+		return $test_files;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		$file = func_get_arg( 0 );
+		$pass = [
+			'class-test.php',
+			'class-two-parts.php',
+		];
+		if ( in_array( $file, $pass, true ) ) {
+			return [];
+		}
+		return [
+			5 => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}

--- a/HM/Tests/Files/ClassFileNameUnitTest/class-Foo.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/class-Foo.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Foo {}

--- a/HM/Tests/Files/ClassFileNameUnitTest/class-bar.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/class-bar.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Test {}

--- a/HM/Tests/Files/ClassFileNameUnitTest/class-test.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/class-test.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Test {}

--- a/HM/Tests/Files/ClassFileNameUnitTest/class-two-parts.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/class-two-parts.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Two_Parts {}

--- a/HM/Tests/Files/ClassFileNameUnitTest/class-two_parts.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/class-two_parts.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Two_Parts {}

--- a/HM/Tests/Files/ClassFileNameUnitTest/class-twoparts.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/class-twoparts.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Two_Parts {}

--- a/HM/Tests/Files/ClassFileNameUnitTest/test.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest/test.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+class Test {}

--- a/HM/Tests/Files/FunctionFileNameUnitTest.php
+++ b/HM/Tests/Files/FunctionFileNameUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace HM\Tests\Files;
+
+use DirectoryIterator;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class FunctionFileNameUnitTest extends AbstractSniffUnitTest {
+	/**
+	 * Get files to test against.
+	 *
+	 * Overridden from base to use the directory instead.
+	 */
+	protected function getTestFiles( $test_base_dir ) {
+		$test_base_dir = rtrim( $test_base_dir, '.' );
+		$test_files = [];
+
+		$di = new DirectoryIterator( $test_base_dir );
+
+		foreach ( $di as $file ) {
+			if ( $file->isDot() ) {
+				continue;
+			}
+
+			$test_files[] = $file->getPathname();
+		}
+
+		// Put them in order.
+		sort( $test_files );
+
+		return $test_files;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		$file = func_get_arg( 0 );
+		$pass = [
+			'namespace.php',
+		];
+		if ( in_array( $file, $pass, true ) ) {
+			return [];
+		}
+		return [
+			5 => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}

--- a/HM/Tests/Files/FunctionFileNameUnitTest/namespace.php
+++ b/HM/Tests/Files/FunctionFileNameUnitTest/namespace.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+function foo() {}

--- a/HM/Tests/Files/FunctionFileNameUnitTest/not-namespace.php
+++ b/HM/Tests/Files/FunctionFileNameUnitTest/not-namespace.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+function foo() {}

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace HM\Tests\Files;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class NamespaceDirectoryNameUnitTest extends AbstractSniffUnitTest {
+	/**
+	 * Get files to test against.
+	 *
+	 * Overridden from base to use the directory instead.
+	 */
+	protected function getTestFiles( $test_base_dir ) {
+		$test_base_dir = rtrim( $test_base_dir, '.' );
+		$test_files = [];
+
+		$di = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $test_base_dir )
+		);
+
+		foreach ( $di as $file ) {
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+
+			$test_files[] = $file->getPathname();
+		}
+
+		// Put them in order.
+		sort( $test_files );
+
+		return $test_files;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		$file = func_get_arg( 0 );
+		switch ( $file ) {
+			case 'pass.php':
+				return [];
+
+			default:
+				return [
+					3 => 1,
+				];
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/pass.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/pass.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/fail.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/fail.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/tests/more/fail.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/tests/more/fail.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/tests/pass.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/tests/pass.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/tests/more/fail.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/tests/more/fail.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/tests/pass.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/tests/pass.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;

--- a/HM/Tests/Layout/OrderUnitTest.php
+++ b/HM/Tests/Layout/OrderUnitTest.php
@@ -1,6 +1,10 @@
 <?php
 
-class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
+namespace HM\Tests\Layout;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class OrderUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.fail
+++ b/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.fail
@@ -1,0 +1,6 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+use \HM\Other;
+use \WP_Post;

--- a/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.php
+++ b/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace HM\Tests\Namespaces;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class NoLeadingSlashOnUseUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		$file = func_get_arg( 0 );
+		switch ( $file ) {
+			case 'NoLeadingSlashOnUseUnitTest.success':
+				return [];
+
+			case 'NoLeadingSlashOnUseUnitTest.fail':
+				return [
+					5 => 1,
+					6 => 1,
+				];
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}

--- a/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.success
+++ b/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.success
@@ -1,0 +1,6 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+use HM\Other;
+use WP_Post;

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,8 @@
 		"wp-coding-standards/wpcs": "^0.13.1",
 		"fig-r/psr2r-sniffer": "dev-master",
 		"squizlabs/php_codesniffer": "^3.1"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0",
 	"require": {
 		"wp-coding-standards/wpcs": "^0.13.1",
-		"fig-r/psr2r-sniffer": "^0.4.1"
+		"fig-r/psr2r-sniffer": "dev-master",
+		"squizlabs/php_codesniffer": "^3.1"
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+>
+	<testsuites>
+		<!-- Default test suite to run all tests -->
+		<testsuite>
+			<file>tests/AllSniffs.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 		<!-- Default test suite to run all tests -->
 		<testsuite>
 			<file>tests/AllSniffs.php</file>
+			<file>tests/FixtureTests.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -124,18 +124,23 @@ phpcs also includes ESLint checking based upon the `eslint:recommended` standard
 
 ### Running tests
 
-To run the tests locally you need a checkout of PHP Code Sniffer, any other
-type of install that isn't v3 or higher will not have the tests included.
+To run the tests locally, you'll need the source version of PHP CodeSniffer.
+
+If you haven't already installed your Composer dependencies:
 
 ```bash
-git clone -b 2.8.1 git@github.com:squizlabs/PHP_CodeSniffer
-cd PHP_CodeSniffer
-composer install
-scripts/phpcs --config-set installed_paths /path/to/this/repo
-vendor/bin/phpunit --filter HM
+composer install --prefer-source --dev
 ```
 
-### Writing tests
+If you already have, and need to convert the phpcs directory to a source version:
+
+```bash
+rm -r vendor/squizlabs/php_codesniffer
+composer install --prefer-source --dev
+composer dump-autoload
+```
+
+### Writing sniff tests
 
 To add tests you should mirror the directory structure of the sniffs. For example a test
 for `HM/Sniffs/Layout/OrderSniff.php` would require the following files:
@@ -152,12 +157,14 @@ A basic unit test class looks like the following:
 ```php
 <?php
 
+namespace HM\Tests\Layout;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Class name must follow the directory structure to be autoloaded correctly.
- * 
- * **NO NAMESPACES!!**
  */
-class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
+class OrderUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/readme.md
+++ b/readme.md
@@ -181,3 +181,28 @@ class HM_Tests_Layout_OrderUnitTest extends AbstractSniffUnitTest {
 
 }
 ```
+
+
+### Fixture Tests
+
+Rather than testing sniffs individually, `FixtureTests.php` also tests the files in the `tests/fixtures` directory and ensures that whole files pass.
+
+To add an expected-pass file, simply add it into `tests/fixtures/pass` in the appropriate subdirectory/file.
+
+To add an expected-fail file, add it into `tests/fixtures/fail` in the appropriate subdirectory/file. You then need to add the expected errors to the JSON file accompanying the tested file (i.e. the filename with `.json` appended). This file should contain a valid JSON object keyed by line number, with each item being a list of error objects:
+
+```json
+{
+	"1": [
+		{
+			"source": "HM.Files.FunctionFileName.WrongFile",
+			"type": "error"
+		}
+	]
+}
+```
+
+An error object contains:
+
+* `source`: Internal phpcs error code; use the `-s` flag to `phpcs` to get the code.
+* `type`: One of `error` or `warning`, depending on the check's severity.

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * A test class for testing all sniffs for installed standards.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace HM\CodingStandards\Tests;
+
+use PHP_CodeSniffer\Util\Standards;
+use PHP_CodeSniffer\Autoload;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPUnit\TextUI\TestRunner;
+use PHPUnit\Framework\TestSuite;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class AllSniffs {
+	/**
+	 * Prepare the test runner.
+	 *
+	 * @return void
+	 */
+	public static function main() {
+		TestRunner::run( self::suite() );
+	}
+
+	/**
+	 * Add all sniff unit tests into a test suite.
+	 *
+	 * Sniff unit tests are found by recursing through the 'Tests' directory
+	 * of each installed coding standard.
+	 *
+	 * @return \PHPUnit\Framework\TestSuite
+	 */
+	public static function suite() {
+		$GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']   = array();
+		$GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'] = array();
+
+		$suite = new TestSuite( 'HM Standards' );
+
+		$standards_dir = dirname( __DIR__ ) . '/HM';
+		$all_details = Standards::getInstalledStandardDetails( false, $standards_dir );
+		$details = $all_details['HM'];
+
+		Autoload::addSearchPath( $details['path'], $details['namespace'] );
+
+		$test_dir = $details['path'] . '/Tests/';
+		if ( is_dir( $test_dir ) === false ) {
+			// No tests for this standard.
+			return $suite;
+		}
+
+		$di = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $test_dir ) );
+
+		foreach ( $di as $file ) {
+			// Skip hidden files.
+			if ( substr( $file->getFilename(), 0, 1 ) === '.' ) {
+				continue;
+			}
+
+			// Tests must have the extension 'php'.
+			$parts = explode( '.', $file );
+			$ext   = array_pop( $parts );
+			if ( $ext !== 'php' ) {
+				continue;
+			}
+
+			$className = Autoload::loadFile( $file->getPathname() );
+			$GLOBALS['PHP_CODESNIFFER_STANDARD_DIRS'][ $className ] = $details['path'];
+			$GLOBALS['PHP_CODESNIFFER_TEST_DIRS'][ $className ]     = $test_dir;
+			$suite->addTestSuite( $className );
+		}
+
+		return $suite;
+	}
+}

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -18,6 +18,8 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
 class AllSniffs {
+	const TEST_SUFFIX = 'UnitTest.php';
+
 	/**
 	 * Prepare the test runner.
 	 *
@@ -56,15 +58,15 @@ class AllSniffs {
 		$di = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $test_dir ) );
 
 		foreach ( $di as $file ) {
+			$filename = $file->getFilename();
+
 			// Skip hidden files.
-			if ( substr( $file->getFilename(), 0, 1 ) === '.' ) {
+			if ( substr( $filename, 0, 1 ) === '.' ) {
 				continue;
 			}
 
-			// Tests must have the extension 'php'.
-			$parts = explode( '.', $file );
-			$ext   = array_pop( $parts );
-			if ( $ext !== 'php' ) {
+			// Tests must end with "UnitTest.php"
+			if ( substr( $filename, -1 * strlen( static::TEST_SUFFIX ) ) !== static::TEST_SUFFIX ) {
 				continue;
 			}
 

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace HM\CodingStandards\Tests;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Util\Common;
+use PHPUnit\Framework\TestCase;
+
+class FixtureTests extends TestCase {
+	public static function get_files_from_dir( $directory ) {
+		$files = [];
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $directory )
+		);
+
+		foreach ( $iterator as $path => $file ) {
+			if ( ! $file->isFile() || $file->getExtension() === 'json' ) {
+				continue;
+			}
+
+			$files[] = [ $path ];
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Get files from the pass fixtures directory.
+	 *
+	 * @return array List of parameters to provide.
+	 */
+	public static function failing_files() {
+		$directory = __DIR__ . '/fixtures/fail';
+
+		return static::get_files_from_dir( $directory );
+	}
+
+	/**
+	 * Get files from the pass fixtures directory.
+	 *
+	 * @return array List of parameters to provide.
+	 */
+	public static function passing_files() {
+		$directory = __DIR__ . '/fixtures/pass';
+
+		return static::get_files_from_dir( $directory );
+	}
+
+	public function setUp() {
+		$this->config            = new Config();
+		$this->config->cache     = false;
+		$this->config->standards = [ 'HM' ];
+
+		$this->ruleset = new Ruleset( $this->config );
+	}
+
+	/**
+	 * @dataProvider passing_files
+	 */
+	public function test_passing_files( $file ) {
+		$phpcsFile = new LocalFile( $file, $this->ruleset, $this->config );
+		$phpcsFile->process();
+
+		$foundErrors = $phpcsFile->getErrors();
+		$this->assertEquals( [], $foundErrors, 'File should not contain any errors' );
+		$foundWarnings = $phpcsFile->getWarnings();
+		$this->assertEquals( [], $foundWarnings, 'File should not contain any warnings' );
+	}
+
+	/**
+	 * @dataProvider failing_files
+	 */
+	public function test_failing_files( $file ) {
+		$phpcsFile = new LocalFile( $file, $this->ruleset, $this->config );
+		$phpcsFile->process();
+
+		$foundErrors = $phpcsFile->getErrors();
+		$foundWarnings = $phpcsFile->getWarnings();
+
+		$expected_file = $file . '.json';
+		$expected = json_decode( file_get_contents( $expected_file ), true );
+
+		$this->assertEquals(
+			JSON_ERROR_NONE,
+			json_last_error(),
+			sprintf(
+				'Expected JSON should be correctly parsed: %s',
+				json_last_error_msg()
+			)
+		);
+
+		$found = [];
+		foreach ( $foundErrors as $line => $columns ) {
+			foreach ( $columns as $column => $errors ) {
+				foreach ( $errors as $error ) {
+					$found[ $line ][] = [
+						'source' => $error['source'],
+						'type'   => 'error',
+					];
+				}
+			}
+		}
+		foreach ( $foundWarnings as $line => $columns ) {
+			foreach ( $columns as $column => $errors ) {
+				foreach ( $errors as $error ) {
+					$found[ $line ][] = [
+						'source' => $error['source'],
+						'type'   => 'warning',
+					];
+				}
+			}
+		}
+
+		$this->assertEquals( $expected, $found );
+		// var_dump( $foundErrors );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+
+// Check phpcs is installed.
+$phpcs_dir = dirname( __DIR__ ) . '/vendor/squizlabs/php_codesniffer';
+if ( ! file_exists($phpcs_dir)) {
+	throw new Exception( 'Could not find PHP_CodeSniffer. Run `composer install --prefer-source --dev`' );
+}
+
+// Check phpcs' test framework is available.
+$test_file = $phpcs_dir . '/tests/Standards/AllSniffs.php';
+if ( ! file_exists( $test_file ) ) {
+	throw new Exception( "Could not find PHP_CodeSniffer's tests. Make sure you run composer with `--prefer-source`" );
+}
+
+// Require autoloader and bootstrap.
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+require $phpcs_dir . '/tests/bootstrap.php';

--- a/tests/fixtures/fail/not-namespace.php
+++ b/tests/fixtures/fail/not-namespace.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Functions declared outside of `namespace.php` should generate a warning.
+ */
+
+namespace HM\Coding\Standards\Test;
+
+/**
+ * This function should be in namespace.php instead.
+ */
+function foo() {}

--- a/tests/fixtures/fail/not-namespace.php.json
+++ b/tests/fixtures/fail/not-namespace.php.json
@@ -1,0 +1,14 @@
+{
+	"6": [
+		{
+			"source": "HM.Files.NamespaceDirectoryName.NoIncDirectory",
+			"type": "error"
+		}
+	],
+	"11": [
+		{
+			"source": "HM.Files.FunctionFileName.WrongFile",
+			"type": "error"
+		}
+	]
+}

--- a/tests/fixtures/pass/inc/namespace.php
+++ b/tests/fixtures/pass/inc/namespace.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+use WP_Post;
+
+/**
+ * Test function.
+ */
+function run_test( $tester ) {
+	$foo = get_foo();
+
+	foreach ( $foo as $x => &$y ) {
+		if ( ! $y ) {
+			continue;
+		}
+
+		echo $y;
+	}
+
+	return $foo;
+}
+
+/**
+ * Anonymous functions with `use` should not trigger an order warning.
+ */
+function anonymous_function() {
+	$x = 0;
+
+	return function () use ( $x ) {
+		$x++;
+		return $x;
+	};
+}

--- a/tests/fixtures/pass/plugin.php
+++ b/tests/fixtures/pass/plugin.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Primary plugin file.
+ *
+ * This file should be excluded from the namespace directory test, as it's
+ * allowed to include files and run functions.
+ */
+
+namespace HM\Coding\Standards\Test;
+
+require __DIR__ . '/inc/namespace.php';
+
+bootstrap();


### PR DESCRIPTION
Requires phpcs 3.1 from #31.

Fixes #27.