### PR TITLE
Update WPCS to ^0.14.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"type": "project",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"wp-coding-standards/wpcs": "^0.13.1",
+		"wp-coding-standards/wpcs": "^0.14.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "^3.1"
 	},


### PR DESCRIPTION
WPCS [release 0.14.0](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/0.14.0) modified the WordPress VIP sniffs to no longer complain about uncached term functions like `get_term_by()`.

These functions used to be uncached, and you had to use VIP's alternatives. But since 4.8, they use a `WP_Term_Query` internally.

I'd like to update this, as we're using the Core functions get lots of false positives for this. We're using `dev-master`, so no need for a new release.