### PR TITLE
Add support for a .phpcsignore file

### DIFF
--- a/HM/bootstrap.php
+++ b/HM/bootstrap.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace HM\Sniffs;
+
+/**
+ * Is the ignore file line a functional one?
+ *
+ * @return bool True for real exclusion lines, false for comments or empty lines.
+ */
+function is_functional_line( $line ) {
+	if ( empty( $line ) ) {
+		return false;
+	}
+
+	return $line[0] !== '#';
+}
+
+/**
+ * Get ignore patterns from an ignore file.
+ *
+ * @param string $file Path to the ignore file.
+ * @param string $directory Directory to treat paths as relative to.
+ * @return string[] List of ignore rules.
+ */
+function get_ignores_from_file( $file, $directory ) {
+	$content = file_get_contents( $file );
+	if ( empty( $content ) ) {
+		return [];
+	}
+
+	$lines = explode( "\n", $content );
+
+	// Strip empty or comment lines.
+	$lines = array_map( 'trim', $lines );
+	$lines = array_filter( $lines, __NAMESPACE__ . '\\is_functional_line' );
+
+	// Make the ignore patterns absolute.
+	$lines = array_map( function ( $rule ) use ( $directory ) {
+		// Strip leading ./
+		if ( substr( $rule, 0, 2 ) === './' ) {
+			$rule = substr( $rule, 2 );
+		}
+
+		return $directory . DIRECTORY_SEPARATOR . $rule;
+	}, $lines );
+
+	return $lines;
+}
+
+/**
+ * Attach additional ignore patterns to the runner.
+ *
+ * @param \PHP_CodeSniffer\Runner $runner CodeSniffer runner instance.
+ */
+function attach_to_runner( $runner ) {
+	$paths = $runner->config->files;
+	$ignored = $runner->config->ignored;
+
+	// Find exclusion files.
+	$did_change = false;
+	foreach ( $paths as $path ) {
+		// Only use ignore files for directories.
+		if ( ! is_dir( $path ) ) {
+			continue;
+		}
+
+		// Find an ignore file.
+		$directory = $path;
+		$ignore_file = $directory . '/.phpcsignore';
+		if ( ! file_exists( $ignore_file ) ) {
+			continue;
+		}
+		if ( PHP_CODESNIFFER_VERBOSITY > 1 ) {
+			echo "\tAdding exclusion rules from $ignore_file\n";
+		}
+
+		$extra_ignores = get_ignores_from_file( $ignore_file, $directory );
+		if ( PHP_CODESNIFFER_VERBOSITY > 1 ) {
+			foreach ( $extra_ignores as $rule ) {
+				echo "\t\t=> $rule\n";
+			}
+		}
+
+		$did_change = true;
+		$ignored = array_merge( $ignored, $extra_ignores );
+	}
+
+	if ( $did_change ) {
+		$runner->config->ignored = $ignored;
+	}
+}
+
+attach_to_runner( $GLOBALS['runner'] );

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -10,6 +10,8 @@
 	<exclude-pattern>*.js</exclude-pattern>
 	<exclude-pattern>*.css</exclude-pattern>
 
+	<autoload>./bootstrap.php</autoload>
+
 	<!-- Include everything in the VIP standard... -->
 	<rule ref="WordPress-VIP">
 		<!-- ...Except for VIP-specific things -->

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,25 @@ script:
 	- vendor/bin/phpcs --standard=vendor/humanmade/coding-standards .
 ```
 
+### Excluding Files
+
+This standard includes special support for a `.phpcsignore` file (in the future, this should be [built into phpcs itself](https://github.com/squizlabs/PHP_CodeSniffer/issues/1884)). Simply place a `.phpcsignore` file in your root directory (wherever you're going to run `phpcs` from).
+
+The format of this file is similar to `.gitignore` and similar files: one pattern per line, comment lines should start with a `#`, and whitespace-only lines are ignored:
+
+```
+# Exclude our tests directory.
+tests/
+
+# Exclude any file ending with ".inc"
+*\.inc
+```
+
+Note that the patterns should match [the PHP_CodeSniffer style](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders): `*` is translated to `.*` for convenience, but all other characters work like a regular expression.
+
+Patterns are relative to the directory that the `.phpcsignore` file lives in. On load, they are translated to absolute patterns: e.g. `*/tests/*` in `/your/dir/.phpcsignore` will become `/your/dir/.*/tests/.*` as a regular expression. **This differs from the regular PHP_CodeSniffer practice.**
+
+
 ### Advanced/Extending
 
 If you want to add further rules (such as WordPress.com VIP-specific rules), you can create your own custom standard file (e.g. `phpcs.ruleset.xml`):


### PR DESCRIPTION
To match `.eslintignore` and `.gitignore`, we should support a `.phpcsignore`. This removes one of the big reasons you'd need a `phpcs.ruleset.xml` in many repos.

See https://github.com/squizlabs/PHP_CodeSniffer/issues/1884