### PR TITLE
Make index pass its own rules

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -5,7 +5,7 @@ module.exports = {
 	'root': true,
 	'env': {
 		'browser': true,
-		'es6': true
+		'es6': true,
 	},
 	'extends': [
 		'eslint:recommended',
@@ -14,14 +14,12 @@ module.exports = {
 	'parserOptions': {
 		'ecmaFeatures': {
 			'experimentalObjectRestSpread': true,
-			'jsx': true
+			'jsx': true,
 		},
-		'sourceType': 'module'
+		'sourceType': 'module',
 	},
 	'rules': {
-		'array-bracket-spacing': [ 'error', 'always', {
-			'objectsInArrays': false,
-		} ],
+		'array-bracket-spacing': [ 'error', 'always' ],
 		'block-spacing': [ 'error' ],
 		'brace-style': [ 'error', '1tbs' ],
 		'comma-spacing': [ 'error', {
@@ -33,11 +31,10 @@ module.exports = {
 		'key-spacing': [ 'error', {
 			'beforeColon': false,
 			'afterColon': true,
-			'align': 'value'
 		} ],
 		'keyword-spacing': [ 'error', {
 			'after': true,
-			'before': true
+			'before': true,
 		} ],
 		'eol-last': [ 'error', 'unix' ],
 		'func-call-spacing': [ 'error' ],
@@ -47,7 +44,7 @@ module.exports = {
 			'named': 'never',
 		} ],
 		'space-in-parens': [ 'warn', 'always', {
-			'exceptions': [ 'empty' ]
+			'exceptions': [ 'empty' ],
 		} ],
 		'indent': [ 'error', 'tab', {
 			'SwitchCase': 1,
@@ -71,6 +68,7 @@ module.exports = {
 		} ],
 		'object-curly-newline': [ 'error', {
 			'multiline': true,
+			'consistent': true,
 		} ],
 		'object-curly-spacing': [ 'error', 'always' ],
 		'arrow-parens': [ 'error', 'as-needed' ],

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -1,6 +1,3 @@
-/* eslint quote-props: ["error", "always"] */
-// Quote properties for consistency in this file only
-// (Many ESLint rules use key names that require quotation marks)
 module.exports = {
 	'root': true,
 	'env': {
@@ -20,14 +17,24 @@ module.exports = {
 	},
 	'rules': {
 		'array-bracket-spacing': [ 'error', 'always' ],
+		'arrow-parens': [ 'error', 'as-needed' ],
+		'arrow-spacing': [ 'error', {
+			'before': true,
+			'after': true,
+		} ],
 		'block-spacing': [ 'error' ],
 		'brace-style': [ 'error', '1tbs' ],
+		'comma-dangle': [ 'error', 'always-multiline' ],
 		'comma-spacing': [ 'error', {
 			'before': false,
 			'after': true,
 		} ],
-		'comma-dangle': [ 'error', 'always-multiline' ],
+		'eol-last': [ 'error', 'unix' ],
 		'eqeqeq': [ 'error' ],
+		'func-call-spacing': [ 'error' ],
+		'indent': [ 'error', 'tab', {
+			'SwitchCase': 1,
+		} ],
 		'key-spacing': [ 'error', {
 			'beforeColon': false,
 			'afterColon': true,
@@ -36,8 +43,24 @@ module.exports = {
 			'after': true,
 			'before': true,
 		} ],
-		'eol-last': [ 'error', 'unix' ],
-		'func-call-spacing': [ 'error' ],
+		'linebreak-style': [ 'error', 'unix' ],
+		'no-console': [ 'warn' ],
+		'no-mixed-spaces-and-tabs': [ 'error', 'smart-tabs' ],
+		'no-multiple-empty-lines': [ 'error', {
+			'max': 1,
+		} ],
+		'no-trailing-spaces': [ 'error' ],
+		'no-var': [ 'warn' ],
+		'object-curly-newline': [ 'error', {
+			'minProperties': 2,
+			'consistent': true,
+		} ],
+		'object-curly-spacing': [ 'error', 'always' ],
+		'quotes': [ 'error', 'single' ],
+		'semi-spacing': [ 'error', {
+			'before': false,
+			'after': true,
+		} ],
 		'space-before-function-paren': [ 'error', {
 			'anonymous': 'always',
 			'asyncArrow': 'always',
@@ -46,16 +69,6 @@ module.exports = {
 		'space-in-parens': [ 'warn', 'always', {
 			'exceptions': [ 'empty' ],
 		} ],
-		'indent': [ 'error', 'tab', {
-			'SwitchCase': 1,
-		} ],
-		'no-mixed-spaces-and-tabs': [ 'error', 'smart-tabs' ],
-		'linebreak-style': [ 'error', 'unix' ],
-		'quotes': [ 'error', 'single' ],
-		'semi-spacing': [ 'error', {
-			'before': false,
-			'after': true,
-		} ],
 		'space-unary-ops': [ 'error', {
 			'words': true,
 			'nonwords': false,
@@ -63,23 +76,7 @@ module.exports = {
 				'!': true,
 			},
 		} ],
-		'no-multiple-empty-lines': [ 'error', {
-			'max': 1,
-		} ],
-		'object-curly-newline': [ 'error', {
-			'multiline': true,
-			'consistent': true,
-		} ],
-		'object-curly-spacing': [ 'error', 'always' ],
-		'arrow-parens': [ 'error', 'as-needed' ],
-		'arrow-spacing': [ 'error', {
-			'before': true,
-			'after': true,
-		} ],
 		'yoda': [ 'error', 'never' ],
-		'no-console': [ 'warn' ],
-		'no-trailing-spaces': [ 'error' ],
-		'no-var': [ 'warn' ],
 		'react/jsx-curly-spacing': [ 'error', 'always' ],
 	},
 };

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -7,7 +7,7 @@
   },
   "peerDependencies": {
     "babel-eslint": "^7.0.0",
-    "eslint": "^3.11.1",
+    "eslint": "^4.19.0",
     "eslint-config-react-app": "^0.5.0",
     "eslint-plugin-flowtype": "^2.21.0",
     "eslint-plugin-import": "^2.0.1",


### PR DESCRIPTION
This upgrades eslint, adds the “consistent” option for single property object sanity, and adjusts the rules and config file so that it passes its own definitions. 