### PR TITLE
Allow inline statements to drop semicolons

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -24,6 +24,9 @@
 		<exclude name="WordPress.XSS.EscapeOutput" />
 		<exclude name="WordPress.VIP.AdminBarRemoval" />
 
+		<!-- Allow with or without semicolons -->
+		<exclude name="Squiz.PHP.EmbeddedPhp.NoSemicolon" />
+
 		<!--
 		OK, real talk right now. Yoda conditions are ridiculous.
 


### PR DESCRIPTION
Fixes #43. This allows either `<?php inline() ?>` or `<?php inline(); ?>` per personal preference.