### PR TITLE
Ignore line length when checking array alignment

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -64,6 +64,13 @@
 		</properties>
 	</rule>
 
+	<!-- Prefer alignment over line length -->
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="maxColumn" value="1000"/>
+		</properties>
+	</rule>
+
 	<!--
 	HM Rules / HM RULEZZZZ
 


### PR DESCRIPTION
Right now, the alignment check will force you to dealign if the line would be longer than 60 characters long. 🙄  This is set in the [WordPress-Core](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/06f6d5c0f7588601c2823dd7abb7e9022fd658dc/WordPress-Core/ruleset.xml#L83-L88) standard.

PR changes it back to the default (in code) of 1000 columns, aka always align.

See https://github.com/humanmade/hm-stack/pull/448 for where this was failing.