### PR TITLE
Adjust object rules for destructuring

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -52,8 +52,24 @@ module.exports = {
 		'no-trailing-spaces': [ 'error' ],
 		'no-var': [ 'warn' ],
 		'object-curly-newline': [ 'error', {
-			'minProperties': 2,
-			'consistent': true,
+			'ObjectExpression': {
+				'consistent': true,
+				'minProperties': 2,
+				'multiline': true,
+			},
+			'ObjectPattern': {
+				'consistent': true,
+				'multiline': true,
+			},
+			'ImportDeclaration': {
+				'consistent': true,
+				'multiline': true,
+			},
+			'ExportDeclaration': {
+				'consistent': true,
+				'minProperties': 2,
+				'multiline': true,
+			},
 		} ],
 		'object-curly-spacing': [ 'error', 'always' ],
 		'quotes': [ 'error', 'single' ],


### PR DESCRIPTION
Changes the `object-curly-newline` rule to remove the `minProperties` restriction on object patterns (i.e. destructuring assignment) and imports. This makes newlines optional for both, but still enforces consistency.

Fixes #58.