### PR TITLE
Forbid multiple properties on a single line.

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -72,6 +72,7 @@ module.exports = {
 			},
 		} ],
 		'object-curly-spacing': [ 'error', 'always' ],
+		'object-property-newline': [ 'error' ],
 		'quotes': [ 'error', 'single' ],
 		'semi-spacing': [ 'error', {
 			'before': false,


### PR DESCRIPTION
This should handle the following cases: 

*Allow*
```
const x = { a: 1 };
const y = { 
  a: 1,
  b: 2,
};
```

*Disallow*
```
const x = { a: 1, b: 2 };
const y = { 
  a: 1, b: 2,
};
```