### PR TITLE
Update ESLint config peer dependencies

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -96,5 +96,10 @@ module.exports = {
 		'yoda': [ 'error', 'never' ],
 		'react/jsx-curly-spacing': [ 'error', 'always' ],
 		'react/jsx-wrap-multilines': [ 'error' ],
+		'jsx-a11y/anchor-is-valid': [ 'error' ],
+		// href-no-hash has been removed from jsx-a11y: this line silences an error
+		// caused by eslint-config-react-app still using the deprecated rule, and
+		// can be removed once the react-app config is updated to a recent jsx-a11y.
+		'jsx-a11y/href-no-hash': [ 'off' ],
 	},
 };

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -11,21 +11,21 @@
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "chalk": "^2.3.2",
-    "eslint": "^4.19.0",
-    "eslint-config-react-app": "^0.5.0",
-    "eslint-plugin-flowtype": "^2.21.0",
-    "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^2.2.3",
-    "eslint-plugin-react": "^6.4.1"
+    "eslint": "^4.19.1",
+    "eslint-config-react-app": "^2.1.0",
+    "eslint-plugin-flowtype": "^2.46.3",
+    "eslint-plugin-import": "^2.11.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.7.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.0.0",
-    "eslint": "^4.19.0",
-    "eslint-config-react-app": "^0.5.0",
-    "eslint-plugin-flowtype": "^2.21.0",
-    "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^2.2.3",
-    "eslint-plugin-react": "^6.4.1"
+    "babel-eslint": "^7.2.3",
+    "eslint": "^4.19.1",
+    "eslint-config-react-app": "^2.1.0",
+    "eslint-plugin-flowtype": "^2.46.3",
+    "eslint-plugin-import": "^2.11.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.7.0"
   },
   "files": [
     ".eslintrc",


### PR DESCRIPTION
Fixes #56 

The update process to the latest available versions of all packages was generally straightforward, excepting one new jsx-a11y rule that the react app configuration does not yet support. I worked around this by swapping the deprecated rule out for the new one in our own config.

This could use some more testing in real projects, so anybody who can `npm link` this in and give it a run, please report your findings!