### PR TITLE
Lock the phpcs minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"wp-coding-standards/wpcs": "^0.14.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
-		"squizlabs/php_codesniffer": "^3.1"
+		"squizlabs/php_codesniffer": "~3.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"


### PR DESCRIPTION
phpcs has a pretty loose interpretation of semantic versioning, so we need to use the tilde operator rather than the caret operator. This ensures that it's locked to 3.2.x rather than 3.x.x.

Fixes #79.