### PR TITLE
Adding composer installers to required packages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
 	"type": "project",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"composer/installers": "~1.0",
 		"wp-coding-standards/wpcs": "^0.14.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "~3.2.0"


### PR DESCRIPTION
This allows us to install the HM coding standards a directory we specify.

In my case, I have my vendor dir set to `mu-plugins` which allows the autoloading file to be picked up by WP and the dependencies available within WP.

But, in doing so HM coding standards are installed to `mu-plugins`. By adding the dependency of `composer/installers` it allows someone to specify the install directory regardless of the set vendor directory.

```
    "extra": {
        "installer-paths": {
            "vendor/humanmade/{$name}/": ["humanmade/coding-standards"]
        }
    }
```

Composer documentation around this: https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md