### PR TITLE
use ecmaVersion 2018

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -9,8 +9,8 @@ module.exports = {
 		'react-app',
 	],
 	'parserOptions': {
+		'ecmaVersion': 2018, 
 		'ecmaFeatures': {
-			'experimentalObjectRestSpread': true,
 			'jsx': true,
 		},
 		'sourceType': 'module',


### PR DESCRIPTION
See https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread

`(node:1244) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "humanmade")`