### PR TITLE
Update PHPCS to v3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"wp-coding-standards/wpcs": "^0.14.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
-		"squizlabs/php_codesniffer": "~3.2.0"
+		"squizlabs/php_codesniffer": "~3.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,17 @@
 	"type": "project",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"php": ">=7.1",
 		"wp-coding-standards/wpcs": "^0.14.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "~3.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"
+	},
+	"config": {
+		"platform": {
+			"php": "7.1"
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.1",
 		"wp-coding-standards/wpcs": "^0.14.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
-		"squizlabs/php_codesniffer": "~3.3.0"
+		"squizlabs/php_codesniffer": "~3.4.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,5 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"
-	},
-	"config": {
-		"platform": {
-			"php": "7.1"
-		}
 	}
 }

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -54,6 +54,10 @@ class FixtureTests extends TestCase {
 		$this->config->cache     = false;
 		$this->config->standards = [ 'HM' ];
 
+		// Keeping the tabWidth set inline with WPCS.
+		// See: https://github.com/humanmade/coding-standards/pull/88#issuecomment-464076803
+		$this->config->tabWidth = 4;
+
 		$this->ruleset = new Ruleset( $this->config );
 	}
 


### PR DESCRIPTION
PHPCS 3.3 included a plethora of useful bugfixes and improvements and will improve the Linter sniffing for several clients.

Reference: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0 for a more exhaustive list of bugfixes.

Resolves #70 
Resolves #110 