### PR TITLE
Add --dev flag to Composer HM standards inclusion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ This is a codified version of [the Human Made style guide](http://engineering.hm
 
 ## Setup
 
-1. `composer require humanmade/coding-standards`
+1. `composer require --dev humanmade/coding-standards`
 2. Run the following command to run the standards checks:
 
 ```


### PR DESCRIPTION
The readme for requiring our coding standards gave a command that included them as a production dependency. The standard set should only be included in a development environment so adding the `--dev` flag to the command to place it in the appropriate list.