### PR TITLE
Attempt to remove assignment alignment rule

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -29,6 +29,7 @@
 
 		<!-- Exclude other conflicting rules -->
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.NotSameWarning" />
 
 		<!--
 		OK, real talk right now. Yoda conditions are ridiculous.
@@ -53,6 +54,8 @@
 
 	</rule>
 
+	<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
+
 	<!-- Allow the use of filesystem functions -->
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<properties>
@@ -64,13 +67,6 @@
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>
 			<property name="additionalWordDelimiters" value="."/>
-		</properties>
-	</rule>
-
-	<!-- Prefer alignment over line length -->
-	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
-		<properties>
-			<property name="maxColumn" value="1000"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
For parity with our JS rules (which do not require alignment for objects or assignment), and as discussed in #61 and #47, we should not enforce assignment alignment.

I have likely done this incorrectly, and am not sure how best to test locally, so could use assistance getting this PR up to snuff so we can close out those issues.