### PR TITLE
Allow json_encode / json_decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased (0.7.0)
 
 ### Changed
- - Exclude `load.php` from `NamespaceDirectoryNameSniff`
+ - Exclude `load.php` from `NamespaceDirectoryNameSniff` #131
+ - Allow `json_encode` / `json_decode` function usage #97
 
 ## 0.6.0 (April 2, 2019)
 

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -70,6 +70,7 @@
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<properties>
 			<property name="exclude" value="file_get_contents,file_system_read" />
+			<property name="exclude" value="json_encode,json_decode" />
 		</properties>
 	</rule>
 


### PR DESCRIPTION
Given we have PHP 7+, we don't need to use wp_json_encode / wp_json_decode. Using the WP alternatives is also not easy in things like SUNRISE or wp-config.php as those functions may not be yet available.