### PR TITLE
Allow trigger_error

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -29,6 +29,7 @@
 
 		<!-- Exclude other conflicting rules -->
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
 
 		<!--
 		OK, real talk right now. Yoda conditions are ridiculous.


### PR DESCRIPTION
This is a genuinely useful function for reporting errors in production. Due to how the WordPress sniff is written, we can't use the same style of excluding as the other dissalowed functions, as there's others we want under the "error_log" group.