### PR TITLE
Upgrade peer dependency versions

### DIFF
--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -9,23 +9,23 @@
     "test": "node fixtures/test-lint-config"
   },
   "devDependencies": {
-    "babel-eslint": "^7.2.3",
-    "chalk": "^2.3.2",
-    "eslint": "^4.19.1",
-    "eslint-config-react-app": "^2.1.0",
-    "eslint-plugin-flowtype": "^2.46.3",
-    "eslint-plugin-import": "^2.11.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.7.0"
+    "babel-eslint": "^9.0.0",
+    "chalk": "^2.4.1",
+    "eslint": "^5.8.0",
+    "eslint-config-react-app": "^3.0.5",
+    "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-react": "^7.11.1"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
-    "eslint": "^4.19.1",
-    "eslint-config-react-app": "^2.1.0",
-    "eslint-plugin-flowtype": "^2.46.3",
-    "eslint-plugin-import": "^2.11.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.7.0"
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.8.0",
+    "eslint-config-react-app": "^3.0.5",
+    "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-react": "^7.11.1"
   },
   "files": [
     ".eslintrc",

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -9,20 +9,20 @@
     "test": "node fixtures/test-lint-config"
   },
   "devDependencies": {
-    "babel-eslint": "^9.0.0",
+    "babel-eslint": "^10.0.0",
     "chalk": "^2.4.1",
-    "eslint": "^5.8.0",
+    "eslint": "^5.10.0",
     "eslint-config-react-app": "^3.0.5",
-    "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1"
   },
   "peerDependencies": {
-    "babel-eslint": "^9.0.0",
-    "eslint": "^5.8.0",
+    "babel-eslint": "^10.0.0",
+    "eslint": "^5.10.0",
     "eslint-config-react-app": "^3.0.5",
-    "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1"


### PR DESCRIPTION
It's that time again: time to upgrade our peer dependencies! This does bump the eslint version, so if @joehoyle @rmccue I acknowledge we may want to exercise more caution and hold off for a bit. That said, I'm in favor of testing this and then releasing as `0.6.0` to permit projects to take advantage of the changes. Because of how semver handles <1.0 versions a `0.6.0` release won't affect any projects currently using `^0.5.0`, making the change strictly opt-in and forward-facing.

The other benefit is that there was a conflict between `eslint-config-react-app` and `eslint-plugin-jsx-a11y`, which the latest bump to the React App config mercifully resolves.

Resolves #56 