### PR TITLE
Stylelint: Define `function-url-quotes`

### DIFF
--- a/packages/stylelint-config-humanmade/stylelint.json
+++ b/packages/stylelint-config-humanmade/stylelint.json
@@ -18,6 +18,7 @@
     },
     "function-parentheses-space-inside": "always-single-line",
     "function-comma-space-after": "always-single-line",
+    "function-url-quotes": "always",
     "max-line-length": 100,
     "max-empty-lines": 1,
     "max-nesting-depth": [ 2, {


### PR DESCRIPTION
Stylelint is currently (via a parent config, I assume) requiring that _no_ quotes be used within the CSS `url()` function. However, using `url()` without quotes requires special escaping and the potential for forgetting to escape a special character exists, making use with quotes just a little bit safer. I propose that we require quotes in URLs for consistency and ease of use.

Ref: https://drafts.csswg.org/css-values-3/#urls

This PR defines this rule to "always" to match the current spec.