### PR TITLE
Enforce spaces inside media queries.

### DIFF
--- a/packages/stylelint-config-humanmade/stylelint.json
+++ b/packages/stylelint-config-humanmade/stylelint.json
@@ -33,6 +33,7 @@
     "max-nesting-depth": [ 2, {
       "ignore": [ "blockless-at-rules" ]
     } ],
+    "media-feature-parentheses-space-inside": "always",
     "rule-empty-line-before" : [
       "always",
       {


### PR DESCRIPTION
Adds a [`media-feature-parentheses-space-inside` rule](https://stylelint.io/user-guide/rules/media-feature-parentheses-space-inside/) to enforce spaces inside media queries.

The purpose of this change is for consistency with the rule `function-parentheses-space-inside`. I noticed it was missing when @kucrut picked up an error (mine) on a client project.

cc @humanmade/frontend  
