### PR TITLE
Remove `href-no-hash` Rule

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -9,7 +9,7 @@ module.exports = {
 		'react-app',
 	],
 	'parserOptions': {
-		'ecmaVersion': 2018, 
+		'ecmaVersion': 2018,
 		'ecmaFeatures': {
 			'jsx': true,
 		},
@@ -97,9 +97,5 @@ module.exports = {
 		'react/jsx-curly-spacing': [ 'error', 'always' ],
 		'react/jsx-wrap-multilines': [ 'error' ],
 		'jsx-a11y/anchor-is-valid': [ 'error' ],
-		// href-no-hash has been removed from jsx-a11y: this line silences an error
-		// caused by eslint-config-react-app still using the deprecated rule, and
-		// can be removed once the react-app config is updated to a recent jsx-a11y.
-		'jsx-a11y/href-no-hash': [ 'off' ],
 	},
 };


### PR DESCRIPTION
As @ntwb pointed out in #101, we should now remove the `href-no-hash` rule as `eslint-config-react-app` updated their dependencies quite a while ago so this rule should no longer be needed.

Ref: https://github.com/facebook/create-react-app/pull/2690

⚠️ this is built on top of #101 and that will need to be merged first.