### PR TITLE
Set Composer Library Type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "humanmade/coding-standards",
 	"description": "Human Made coding standards",
-	"type": "project",
+	"type": "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"wp-coding-standards/wpcs": "^0.14.0",


### PR DESCRIPTION
For the purposes of Composer, these coding standards are a PHPCS standard and currently we've only marked this as a "project". We should be more specific about the type of library this is for sorting and path-directing purposes.