### PR TITLE
Require space in curly braces for children

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -94,7 +94,10 @@ module.exports = {
 			},
 		} ],
 		'yoda': [ 'error', 'never' ],
-		'react/jsx-curly-spacing': [ 'error', 'always' ],
+		'react/jsx-curly-spacing': [ 'error', {
+			'when': 'always',
+			'children': true,
+		} ],
 		'react/jsx-wrap-multilines': [ 'error' ],
 		'jsx-a11y/anchor-is-valid': [ 'error' ],
 		// href-no-hash has been removed from jsx-a11y: this line silences an error


### PR DESCRIPTION
Currently this code is allowed. I think we should enforce a space inside curly braces for children.

```
<div>
	{children}
	{foo && (
		<p>Foo</p>
	)}
</div>
```

Expected:

```
<div>
	{ children }
	{ foo && (
		<p>Foo</p>
	) }
</div>
```