### PR TITLE
Remove Composer References in NPM Packages

### DIFF
--- a/packages/eslint-config-humanmade/readme.md
+++ b/packages/eslint-config-humanmade/readme.md
@@ -2,8 +2,6 @@
 
 Human Made coding standards for JavaScript.
 
-We highly recommend using this [via the `humanmade/coding-standards` Composer package.](https://github.com/humanmade/coding-standards).
-
 ## Installation
 
 This package is an ESLint shareable configuration, and requires `babel-eslint`, `eslint`, `eslint-config-react-app`, `eslint-plugin-flowtype`, `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`.

--- a/packages/stylelint-config-humanmade/readme.md
+++ b/packages/stylelint-config-humanmade/readme.md
@@ -2,8 +2,6 @@
 
 Human Made coding standards for CSS and SCSS.
 
-We highly recommend using this [via the `humanmade/coding-standards` Composer package.](https://github.com/humanmade/coding-standards).
-
 ## Installation
 
 This package is a Stylelint shareable configuration, and requires the `stylelint` library.


### PR DESCRIPTION
We've had a line recommending usage via Composer in both NPM packages but this it no longer recommended. Removing for future users.