### PR TITLE
Restore `allowMultipleArguments`

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -89,6 +89,25 @@
 
 	<rule ref="WordPress.WP.TimezoneChange" />
 
+    <!--
+    Restore the ability to have multiple arguments per line
+
+    WPCS disallowed this behavior in 1.1.0, but we'd like to keep it until
+    there is a reason to disallow this behavior.
+    Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/bb8a48671e213a5588a6439ea52411eeefab4b0f
+    -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="allowMultipleArguments" value="true" />
+        </properties>
+    </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+        <severity phpcs-only="true">0</severity>
+    </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+        <severity phpcs-only="true">0</severity>
+    </rule>
+
 	<!--
 	HM Rules / HM RULEZZZZ
 

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -89,24 +89,24 @@
 
 	<rule ref="WordPress.WP.TimezoneChange" />
 
-    <!--
-    Restore the ability to have multiple arguments per line
+	<!--
+	Restore the ability to have multiple arguments per line
 
-    WPCS disallowed this behavior in 1.1.0, but we'd like to keep it until
-    there is a reason to disallow multiple arguments.
-    Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/bb8a48671e213a5588a6439ea52411eeefab4b0f
-    -->
-    <rule ref="PEAR.Functions.FunctionCallSignature">
-        <properties>
-            <property name="allowMultipleArguments" value="true" />
-        </properties>
-    </rule>
-    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-        <severity phpcs-only="true">0</severity>
-    </rule>
-    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-        <severity phpcs-only="true">0</severity>
-    </rule>
+	WPCS disallowed this behavior in 1.1.0, but we'd like to keep it until
+	there is a reason to disallow multiple arguments.
+	Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/bb8a48671e213a5588a6439ea52411eeefab4b0f
+	-->
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<properties>
+			<property name="allowMultipleArguments" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+		<severity phpcs-only="true">0</severity>
+	</rule>
+	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+		<severity phpcs-only="true">0</severity>
+	</rule>
 
 	<!--
 	HM Rules / HM RULEZZZZ

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -93,7 +93,7 @@
     Restore the ability to have multiple arguments per line
 
     WPCS disallowed this behavior in 1.1.0, but we'd like to keep it until
-    there is a reason to disallow this behavior.
+    there is a reason to disallow multiple arguments.
     Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/bb8a48671e213a5588a6439ea52411eeefab4b0f
     -->
     <rule ref="PEAR.Functions.FunctionCallSignature">

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.1",
-		"wp-coding-standards/wpcs": "^1.2.0",
+		"wp-coding-standards/wpcs": "1.2.1",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "~3.4.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.1",
-		"wp-coding-standards/wpcs": "^1.0.0",
+		"wp-coding-standards/wpcs": "^1.2.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "~3.4.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"


### PR DESCRIPTION
In WPCS 1.1.0, the `allowMultipleArguments` property from `PEAR.Functions.FunctionCallSignature` was disallowed, causing our tests to fail and existing behavior to be altered. 

I re-allowed this to restore expected behavior and updated Composer to more explicitly show which version we are on (`^1.0.0` was already giving us 1.2.1, just without the explicit declaration).

We can easily turn this back off if we decide to alter the behavior in the future. I believe this to be the only "breaking"/expectation-changing behavior from WPCS 1.0.0 -> 1.2.0.