### PR TITLE
Adding VIP phpcs standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
 	"require": {
 		"php": ">=7.1",
 		"wp-coding-standards/wpcs": "^1.0.0",
+		"automattic/vipwpcs": "^0.4.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "~3.4.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"


### PR DESCRIPTION
Adding VIP phpcs standards so we can utilize them within `hm-linter`.