### PR TITLE
Allow load.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Unreleased (0.6.0)
+## Unreleased (0.7.0)
+
+### Changed
+ - Exclude `load.php` from `NamespaceDirectoryNameSniff`
+
+## 0.6.0 (April 2, 2019)
 
 ### Summation:
 - Updated PHPCS to v3.4 #88

--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -50,7 +50,7 @@ class NamespaceDirectoryNameSniff implements Sniff {
 			$directory = str_replace( DIRECTORY_SEPARATOR, '/', $directory );
 		}
 
-		if ( $filename === 'plugin.php' || $filename === 'functions.php' ) {
+		if ( $filename === 'plugin.php' || $filename === 'functions.php' || $filename === 'load.php' ) {
 			// Ignore the main file.
 			return;
 		}

--- a/tests/fixtures/pass/load.php
+++ b/tests/fixtures/pass/load.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Package load file.
+ *
+ * This file should be excluded from the namespace directory test, as it's
+ * allowed to include files and run functions.
+ */
+
+namespace HM\Coding\Standards\Test;
+
+require __DIR__ . '/inc/namespace.php';
+
+bootstrap();


### PR DESCRIPTION
Per composer packages, we use `load.php`, as `plugin.php` doesn't make sense as the entry point name