### PR TITLE
Bump VIPCS Dep to 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"php": ">=7.1",
 		"wp-coding-standards/wpcs": "1.2.1",
-		"automattic/vipwpcs": "^0.4.0",
+		"automattic/vipwpcs": "1.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"squizlabs/php_codesniffer": "~3.4.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"


### PR DESCRIPTION
VIP recently updated their standard set, and bumped their linter bot without a warm-up period. This means that we need to bump our version include so that our linter bot can match theirs. 

Ref: https://github.com/Automattic/VIP-Coding-Standards/releases/tag/1.0.0

Note: VIPCS is incompatible with WPCS 2.*, this won't affect most of our projects but could limit who can upgrade when we bump WPCS.

Resolves #136