### PR TITLE
Test Suite Improvements

### DIFF
--- a/HM/Tests/Classes/OnlyClassInFileUnitTest.php
+++ b/HM/Tests/Classes/OnlyClassInFileUnitTest.php
@@ -4,6 +4,11 @@ namespace HM\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Class OnlyClassInFileUnitTest
+ *
+ * @group hm-sniffs
+ */
 class OnlyClassInFileUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/HM/Tests/Files/ClassFileNameUnitTest.php
+++ b/HM/Tests/Files/ClassFileNameUnitTest.php
@@ -5,6 +5,11 @@ namespace HM\Tests\Files;
 use DirectoryIterator;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Class ClassFileNameUnitTest
+ *
+ * @group hm-sniffs
+ */
 class ClassFileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Get files to test against.

--- a/HM/Tests/Files/FunctionFileNameUnitTest.php
+++ b/HM/Tests/Files/FunctionFileNameUnitTest.php
@@ -5,6 +5,11 @@ namespace HM\Tests\Files;
 use DirectoryIterator;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Class FunctionFileNameUnitTest
+ *
+ * @group hm-sniffs
+ */
 class FunctionFileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Get files to test against.

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
@@ -6,6 +6,11 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Class NamespaceDirectoryNameUnitTest
+ *
+ * @group hm-sniffs
+ */
 class NamespaceDirectoryNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Get files to test against.

--- a/HM/Tests/Layout/OrderUnitTest.php
+++ b/HM/Tests/Layout/OrderUnitTest.php
@@ -4,6 +4,11 @@ namespace HM\Tests\Layout;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Class OrderUnitTest
+ *
+ * @group hm-sniffs
+ */
 class OrderUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.php
+++ b/HM/Tests/Namespaces/NoLeadingSlashOnUseUnitTest.php
@@ -4,6 +4,11 @@ namespace HM\Tests\Namespaces;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Class NoLeadingSlashOnUseUnitTest
+ *
+ * @group hm-sniffs
+ */
 class NoLeadingSlashOnUseUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -11,7 +11,6 @@ namespace HM\CodingStandards\Tests;
 
 use PHP_CodeSniffer\Util\Standards;
 use PHP_CodeSniffer\Autoload;
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHPUnit\TextUI\TestRunner;
 use PHPUnit\Framework\TestSuite;
 use RecursiveDirectoryIterator;

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -16,6 +16,11 @@ use PHPUnit\Framework\TestSuite;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
+/**
+ * Class AllSniffs
+ *
+ * @group sniffs
+ */
 class AllSniffs {
 	const TEST_SUFFIX = 'UnitTest.php';
 
@@ -43,8 +48,8 @@ class AllSniffs {
 		$suite = new TestSuite( 'HM Standards' );
 
 		$standards_dir = dirname( __DIR__ ) . '/HM';
-		$all_details = Standards::getInstalledStandardDetails( false, $standards_dir );
-		$details = $all_details['HM'];
+		$all_details   = Standards::getInstalledStandardDetails( false, $standards_dir );
+		$details       = $all_details['HM'];
 
 		Autoload::addSearchPath( $details['path'], $details['namespace'] );
 

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -18,8 +18,6 @@ use RecursiveIteratorIterator;
 
 /**
  * Class AllSniffs
- *
- * @group sniffs
  */
 class AllSniffs {
 	const TEST_SUFFIX = 'UnitTest.php';

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -46,8 +46,8 @@ class AllSniffs {
 		$suite = new TestSuite( 'HM Standards' );
 
 		$standards_dir = dirname( __DIR__ ) . '/HM';
-		$all_details   = Standards::getInstalledStandardDetails( false, $standards_dir );
-		$details       = $all_details['HM'];
+		$all_details = Standards::getInstalledStandardDetails( false, $standards_dir );
+		$details = $all_details['HM'];
 
 		Autoload::addSearchPath( $details['path'], $details['namespace'] );
 

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -3,10 +3,8 @@
 namespace HM\CodingStandards\Tests;
 
 use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\LocalFile;
-use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;
 
 class FixtureTests extends TestCase {

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -6,12 +6,39 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\LocalFile;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
+/**
+ * Class FixtureTests
+ *
+ * @group fixtures
+ */
 class FixtureTests extends TestCase {
-	public static function get_files_from_dir( $directory ) {
-		$files = [];
-		$iterator = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator( $directory )
+	/**
+	 * Config instance.
+	 *
+	 * @var \PHP_CodeSniffer\Config
+	 */
+	protected $config;
+
+	/**
+	 * Ruleset instance.
+	 *
+	 * @var \PHP_CodeSniffer\Ruleset
+	 */
+	protected $ruleset;
+
+	/**
+	 * Get a lit of files from a directory path.
+	 *
+	 * @param string $directory Directory to recursively look through.
+	 * @return array List of files to run.
+	 */
+	public static function get_files_from_dir( string $directory ) {
+		$files    = [];
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $directory )
 		);
 
 		foreach ( $iterator as $path => $file ) {
@@ -47,6 +74,9 @@ class FixtureTests extends TestCase {
 		return static::get_files_from_dir( $directory );
 	}
 
+	/**
+	 * Setup our ruleset.
+	 */
 	public function setUp() {
 		$this->config            = new Config();
 		$this->config->cache     = false;

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -36,7 +36,7 @@ class FixtureTests extends TestCase {
 	 * @return array List of files to run.
 	 */
 	public static function get_files_from_dir( string $directory ) {
-		$files    = [];
+		$files = [];
 		$iterator = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator( $directory )
 		);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
 
+// Setup some constants that PHPCS uses for testing.
+define( 'PHP_CODESNIFFER_IN_TESTS', true );
+define( 'PHP_CODESNIFFER_CBF', false );
+
 // Check phpcs is installed.
 $phpcs_dir = dirname( __DIR__ ) . '/vendor/squizlabs/php_codesniffer';
 if ( ! file_exists($phpcs_dir)) {


### PR DESCRIPTION
While debugging #81, I made a series of style fixes that keep the code a bit cleaner and easier to read.

 - Removes unused `use` statements
 - Moves classes from `\` to `use`
 - Defines class variables used by the class
 - Adds `@group` definitions for more finite testing
 - Defines some constants that should help PHPCS work more intelligently while testing