### PR TITLE
Add stylelint bundle step to build script

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -7,16 +7,19 @@
     "url": "git+https://github.com/humanmade/coding-standards.git"
   },
   "keywords": [
-     "stylelint",
-     "stylelint-config",
-     "css",
-     "scss",
-     "lint",
-     "linter",
-     "humanmade"
+    "stylelint",
+    "stylelint-config",
+    "css",
+    "scss",
+    "lint",
+    "linter",
+    "humanmade"
   ],
-  "devDependencies": {
+  "dependencies": {
     "stylelint-config-wordpress": "^13.0.0"
+  },
+  "devDependencies": {
+    "stylelint": "^10.0.1"
   },
   "main": ".stylelintrc.json"
 }

--- a/publish.sh
+++ b/publish.sh
@@ -40,5 +40,5 @@ case "$choice" in
 		;;
 esac
 
-#echo "Publishing archives to S3..."
-#aws s3 sync --acl=public-read archives/ s3://hm-linter/standards/
+echo "Publishing archives to S3..."
+aws s3 sync --acl=public-read archives/ s3://hm-linter/standards/

--- a/publish.sh
+++ b/publish.sh
@@ -19,12 +19,17 @@ tar czvf "archives/phpcs-$CURRENT_VERSION.tar.gz" -C phpcs-standard --exclude '*
 yarn install --cwd packages/eslint-config-humanmade
 tar czvf "archives/eslint-$CURRENT_VERSION.tar.gz" -C packages/eslint-config-humanmade .eslintrc index.js package.json node_modules/
 
+# Prepare stylelint
+yarn install --cwd packages/stylelint-config
+tar czvf "archives/stylelint-$CURRENT_VERSION.tar.gz" -C packages/stylelint-config .stylelintrc.json package.json node_modules/
+
 read -p "Bump 'latest' to $CURRENT_VERSION [Y/n]? " choice
 case "$choice" in
 	y|Y|"")
 		echo "Bumping 'latest' to $CURRENT_VERSION"
 		cp "archives/eslint-$CURRENT_VERSION.tar.gz" "archives/eslint-latest.tar.gz"
 		cp "archives/phpcs-$CURRENT_VERSION.tar.gz" "archives/phpcs-latest.tar.gz"
+		cp "archives/stylelint-$CURRENT_VERSION.tar.gz" "archives/stylelint-latest.tar.gz"
 		;;
 	n|N )
 		echo "Skipping 'latest'"
@@ -35,5 +40,5 @@ case "$choice" in
 		;;
 esac
 
-echo "Publishing archives to S3..."
-aws s3 sync --acl=public-read archives/ s3://hm-linter/standards/
+#echo "Publishing archives to S3..."
+#aws s3 sync --acl=public-read archives/ s3://hm-linter/standards/


### PR DESCRIPTION
We're not currently building Stylelint bundles to publish to the Linter bot, which is a required step for Linter Bot to run stylelint. This adds the necessary step to publish and fixes the Stylelint dependencies.