### PR TITLE
Make PHPCompatibilityWP Available via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
 		"wp-coding-standards/wpcs": "1.2.1",
 		"automattic/vipwpcs": "1.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"squizlabs/php_codesniffer": "~3.4.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},


### PR DESCRIPTION
This PR is a pre-cursor to #81 and makes PHPCompatibilityWP available to users of the Linter Bot. This is an incremental improvement only and allows us to provide the package to users without waiting to figure out the test suite problems that are encountered in #81.

This has @tfrommen to thank for this change 👍 