### PR TITLE
Update: WPCS 2.1.1 / VIPCS 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased (1.0.0)
 
+### Updated
+ - Updated WPCS to 2.2.1
+ - Updated VIPCS to 2.0.0
+ - Updated DealerDirect to 0.6
+
 ##  0.8.0 (January 29, 2020)
 
 ### Added:

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -96,7 +96,7 @@
 		<type>error</type>
 	</rule>
 
-	<rule ref="WordPress.WP.TimezoneChange" />
+	<rule ref="WordPress.DateTime.RestrictedFunctions" />
 
 	<!--
 	Restore the ability to have multiple arguments per line

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -25,6 +25,10 @@
 		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 
+		<!-- We like short arrays and ternaries around here -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+		<exclude name="WordPress.PHP.DisallowShortTernary" />
+
 		<!--
 		OK, real talk right now. Yoda conditions are ridiculous.
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"squizlabs/php_codesniffer": "~3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.1",
-		"wp-coding-standards/wpcs": "2.1.1",
+		"wp-coding-standards/wpcs": "2.2.1",
 		"automattic/vipwpcs": "2.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.1",
-		"wp-coding-standards/wpcs": "1.2.1",
-		"automattic/vipwpcs": "1.0.0",
+		"wp-coding-standards/wpcs": "2.1.1",
+		"automattic/vipwpcs": "2.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"squizlabs/php_codesniffer": "~3.4.0",


### PR DESCRIPTION
Updates WP CS and VIP CS packages to latest versions.
VIP CS rules are now compatible with WP CS 2.*
see https://github.com/Automattic/VIP-Coding-Standards/releases/tag/2.0.0

Resolves #130 
Resolves #148