### PR TITLE
Make react hooks and sonarjs eslint plugins available

### DIFF
--- a/packages/eslint-config-humanmade/package-lock.json
+++ b/packages/eslint-config-humanmade/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "eslint-config-humanmade",
+  "version": "0.7.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "eslint-plugin-react-hooks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz",
+      "integrity": "sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==",
+      "dev": true
+    },
+    "eslint-plugin-sonarjs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.5.0.tgz",
+      "integrity": "sha512-XW5MnzlRjhXpIdbULC/qAdJYHWw3rRLws/DyawdlPU/IdVr9AmRK1r2LaCvabwKOAW2XYYSo3kDX58E4MrB7PQ==",
+      "dev": true
+    }
+  }
+}

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -16,7 +16,9 @@
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "^2.3.0",
+    "eslint-plugin-sonarjs": "^0.5.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
## Description
<!--- Provide a detailed description of the change or addition you are proposing -->
Given I want to use some extra linting plugins in my config, and the project is using the HM eslint config, the way to use these extra plugins, and have HM linter bot use them in its review, I need to include these plugins in this `package.json` file.

I'd like to be able to lint my React code with the plugin that enforces the rules of hooks

https://reactjs.org/docs/hooks-rules.html

I want to use the linting rules provided by this package
https://github.com/SonarSource/SonarJS  

This is the accepted way to add custom plugins as was discussed with @rmccue 
