### PR TITLE
Add typescript dev dependency

### DIFF
--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -16,7 +16,8 @@
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "typescript": "^3.7.3"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the typescript npm package
https://www.npmjs.com/package/typescript

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Having the ability to use typescript types checking will allow projects to benefit from stricter type checks in Javascript code without having to write Typescript.

This is supported by the fact that the Gutenberg team are doing the same: https://github.com/WordPress/gutenberg/commit/f7e067b2a08b75a7dd889f87473f3e434153c743#diff-e5e546dd2eb0351f813d63d1b39dbc48

This can be paired with the `eslint` rules `valid-jsdoc` and `require-jsdoc`

To use in a project, developers will simply need to add a `tsconfig.json` file, which should have the key `"noEmit": true,` and run `tsc` on their codebase

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
