### PR TITLE
Limit Fixture Test Standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Updated
  - Bumped `stylelint-config-wordpress` package to v15 from v13 #165
  - Ignore stylelint `at-rule` line break for `if/else/elseif` #170
+ - Restricted fixture tests to load only custom HM sniffs #163
 
 ## 0.7.0 (June 5, 2019)
 

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -86,6 +86,18 @@ class FixtureTests extends TestCase {
 		// See: https://github.com/humanmade/coding-standards/pull/88#issuecomment-464076803
 		$this->config->tabWidth = 4;
 
+		// We want to setup our tests to only load our standards in for testing.
+		$this->config->sniffs = [
+			'HM.Classes.OnlyClassInFile',
+			'HM.Debug.ESLint',
+			'HM.Files.ClassFileName',
+			'HM.Files.FunctionFileName',
+			'HM.Files.NamespaceDirectoryName',
+			'HM.Functions.NamespacedFunctions',
+			'HM.Layout.Order',
+			'HM.Namespaces.NoLeadingSlashOnUse',
+		];
+
 		$this->ruleset = new Ruleset( $this->config );
 	}
 

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -104,6 +104,7 @@ class FixtureTests extends TestCase {
 			'HM.Functions.NamespacedFunctions',
 			'HM.Layout.Order',
 			'HM.Namespaces.NoLeadingSlashOnUse',
+			'HM.Whitespace.MultipleEmptyLines',
 		];
 
 		$this->ruleset = new Ruleset( $this->config );

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Run tests on fixture files against our custom standards.
+ *
+ * This test suite runs our standards against files which have
+ * known errors or known passing conditions. We run these tests
+ * against said fixture files as it's closer to real-world conditions
+ * than isolated unit tests and provides another layer of security.
+ */
 
 namespace HM\CodingStandards\Tests;
 


### PR DESCRIPTION
**Problem:**
We've been loading any and all standards from our HM ruleset within our fixture tests, but the fixture tests only store errors for our specific standards. Loading in other standards is causing all kinds of false errors such as those seen in #81 and #151. I believe that these errors are related to PHPCS autoloading some classes and then our standard coming in and triggering them to load again. PHPCS runs fine and as expected on the command line, but fails in the test suite for the above hard-to-trace reasons. 

**Solution:**
The Ruleset class offers us the ability to limit the standards loaded to a specific subset so that our tests run only against our custom code. Since we're only recording errors on our custom sniffs, there's little point to loading in all the standards for these particular tests. It also cuts the run time for the test suites down by half. Yay 200ms back in your life ;P  

Note that this does remove the ability to smoke test for regressions from updating external rulesets, but I think that we should handle that in a separate test suite anyway.

This fixes the test suite issues seen in both #81 and #151 as seen by these test branch CI runs: https://travis-ci.org/humanmade/coding-standards/builds/630048500 and https://travis-ci.org/humanmade/coding-standards/builds/630048408

https://github.com/squizlabs/PHP_CodeSniffer/blob/278b643f2a5ec1b92fd60b2d7dac034f3a52ea4e/src/Ruleset.php#L177-L191