### PR TITLE
Disallow Usage of `!important` in CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased (0.8.0)
 
+### Added
+ - Disallowed usage of `!important` in CSS
+
 ## 0.7.0 (June 5, 2019)
 
 ### Changed:

--- a/packages/stylelint-config/.stylelintrc.json
+++ b/packages/stylelint-config/.stylelintrc.json
@@ -13,6 +13,7 @@
     "block-closing-brace-newline-before": "always-multi-line",
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-block-single-line-max-declarations": 4,
+    "declaration-no-important": true,
     "declaration-property-unit-blacklist": {
       "font-size": [ "px" ]
     },


### PR DESCRIPTION
This PR adds the stylelint [`declaration-no-important`](https://stylelint.io/user-guide/rules/declaration-no-important) rule which disallows usages of `!important` unless a developer specifically adds a exception comment.

Fixes #144 