### PR TITLE
Bump WordPress stylelint config from v13 to v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased (0.8.0)
 
+### Updated
+ - Bumped `stylelint-config-wordpress` package to v15 from v13
+
 ## 0.7.0 (June 5, 2019)
 
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased (0.8.0)
 
 ### Updated
- - Bumped `stylelint-config-wordpress` package to v15 from v13
+ - Bumped `stylelint-config-wordpress` package to v15 from v13 #165
 
 ## 0.7.0 (June 5, 2019)
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -16,10 +16,10 @@
     "humanmade"
   ],
   "dependencies": {
-    "stylelint-config-wordpress": "^15.0.0"
+    "stylelint-config-wordpress": "^16.0.0"
   },
   "devDependencies": {
-    "stylelint": "^10.1.0"
+    "stylelint": "^12.0.0"
   },
   "main": ".stylelintrc.json"
 }

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -16,10 +16,10 @@
     "humanmade"
   ],
   "dependencies": {
-    "stylelint-config-wordpress": "^13.0.0"
+    "stylelint-config-wordpress": "^15.0.0"
   },
   "devDependencies": {
-    "stylelint": "^10.0.1"
+    "stylelint": "^10.1.0"
   },
   "main": ".stylelintrc.json"
 }


### PR DESCRIPTION
Bumps the WordPress stylelint rules from v13.0 to v16.0. From what I'm reading the only rule change this brings is to add the [`function-calc-no-invalid`](https://stylelint.io/user-guide/rules/function-calc-no-invalid) rule which is a really nice addition and will only flag erroneous usages of `calc`. Is there anything else worth flagging or worth notifying devs of in these versions @ntwb? 

See the following changelogs for more on the releases.
 - https://github.com/WordPress-Coding-Standards/stylelint-config-wordpress/releases
 - https://github.com/kristerkari/stylelint-config-recommended-scss/releases
 - https://github.com/stylelint/stylelint-config-recommended/releases

Resolves #138