### PR TITLE
Enforce Escaping in PHPCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased (0.8.0)
 
+### Added:
+ - Added `WordPress.Security.EscapeOutput` PHPCS rule
+
 ## 0.7.0 (June 5, 2019)
 
 ### Changed:

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -41,8 +41,6 @@
 		assignment in conditionals.
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
-
-		<exclude name="WordPress.Security.EscapeOutput" />
 	</rule>
 
 	<!-- Prefer alignment over line length. -->
@@ -60,6 +58,8 @@
 			<property name="additionalWordDelimiters" value="." />
 		</properties>
 	</rule>
+
+	<rule ref="WordPress.Security.EscapeOutput" />
 
 	<rule ref="WordPress.Security.PluginMenuSlug" />
 	<rule ref="WordPress.Security.PluginMenuSlug.Using__FILE__">

--- a/tests/fixtures/pass/inc/namespace.php
+++ b/tests/fixtures/pass/inc/namespace.php
@@ -15,7 +15,7 @@ function run_test( $tester ) {
 			continue;
 		}
 
-		echo $y;
+		echo esc_html( $y );
 	}
 
 	return $foo;

--- a/tests/fixtures/pass/tests/namespace.php
+++ b/tests/fixtures/pass/tests/namespace.php
@@ -15,7 +15,7 @@ function run_test( $tester ) {
 			continue;
 		}
 
-		echo $y;
+		echo esc_html( $y );
 	}
 
 	return $foo;


### PR DESCRIPTION
We've previously not enforced escaping in our standards set but doing so is important. Here, I add this rule back into our ruleset.

Resolves #102
