### PR TITLE
Add Rule to Detect Consecutive Newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased (0.8.0)
 
 ### Added:
+ - Added PHPCS Rule to Detect Consecutive Newlines #168
  - Enforce semicolons in JS #169
  - Added `WordPress.Security.EscapeOutput` PHPCS rule #166
 

--- a/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
+++ b/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Check multiple consecutive newlines in a file.
+ */
+
+namespace HM\Sniffs\Whitespace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Class that checks for more than one consecutive empty line.
+ *
+ * This sniff is adapted from the MediaWiki Tools ruleset
+ * See: https://github.com/wikimedia/mediawiki-tools-codesniffer/commit/3a6709be2612fad63b9e9ead4e6644c28748edcc#diff-4522e134348f6d4e2efe9ccb7148a254
+ */
+class MultipleEmptyLinesSniff implements Sniff {
+
+	public function register() {
+		return [ T_WHITESPACE ];
+	}
+
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		if ( $stackPtr > 2
+			&& $tokens[$stackPtr - 1]['line'] < $tokens[$stackPtr]['line']
+			&& $tokens[$stackPtr - 2]['line'] === $tokens[$stackPtr - 1]['line']
+		) {
+			// This is the first whitespace token on a line
+			// and the line before this one is not empty,
+			// so this could be the start of a multiple empty line block.
+			$next = $phpcsFile->findNext( T_WHITESPACE, $stackPtr, null, true );
+			$lines = ( $tokens[$next]['line'] - $tokens[$stackPtr]['line'] );
+
+			if ( $lines > 1 ) {
+				// If the next non T_WHITESPACE token is more than 1 line away,
+				// then there were multiple empty lines.
+				$error = 'Multiple empty lines should not exist in a row; found %s consecutive empty lines';
+				$fix   = $phpcsFile->addFixableError(
+					$error,
+					$stackPtr,
+					'MultipleEmptyLines',
+					array( $lines )
+				);
+
+				if ( $fix === true ) {
+					$phpcsFile->fixer->beginChangeset();
+					$i = $stackPtr;
+					while ( $tokens[$i]['line'] !== $tokens[$next]['line'] ) {
+						$phpcsFile->fixer->replaceToken( $i, '' );
+						$i++;
+					}
+					$phpcsFile->fixer->addNewlineBefore( $i );
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+		}
+	}
+}

--- a/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
+++ b/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
@@ -41,39 +41,53 @@ class MultipleEmptyLinesSniff implements Sniff {
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		if (
-			$stackPtr > 2
-			&& $tokens[ $stackPtr - 1 ]['line'] < $tokens[ $stackPtr ]['line']
-			&& $tokens[ $stackPtr - 2 ]['line'] === $tokens[ $stackPtr - 1 ]['line']
-		) {
-			// This is the first whitespace token on a line
-			// and the line before this one is not empty,
-			// so this could be the start of a multiple empty line block.
-			$next = $phpcsFile->findNext( T_WHITESPACE, $stackPtr, null, true );
-			$lines = ( $tokens[ $next ]['line'] - $tokens[ $stackPtr ]['line'] );
-
-			if ( $lines > 1 ) {
-				// If the next non T_WHITESPACE token is more than 1 line away,
-				// then there were multiple empty lines.
-				$error = 'Multiple empty lines should not exist in a row; found %s consecutive empty lines';
-				$fix   = $phpcsFile->addFixableError(
-					$error,
-					$stackPtr,
-					'MultipleEmptyLines',
-					[ $lines ]
-				);
-
-				if ( $fix === true ) {
-					$phpcsFile->fixer->beginChangeset();
-					$i = $stackPtr;
-					while ( $tokens[ $i ]['line'] !== $tokens[ $next ]['line'] ) {
-						$phpcsFile->fixer->replaceToken( $i, '' );
-						$i++;
-					}
-					$phpcsFile->fixer->addNewlineBefore( $i );
-					$phpcsFile->fixer->endChangeset();
-				}
-			}
+		// Only continue if the line position is greater than a file opener line.
+		if ( $stackPtr <= 2 ) {
+			return;
 		}
+
+		if ( $tokens[ $stackPtr - 1 ]['line'] >= $tokens[ $stackPtr ]['line'] ) {
+			return;
+		}
+
+		if ( $tokens[ $stackPtr - 2 ]['line'] !== $tokens[ $stackPtr - 1 ]['line'] ) {
+			return;
+		}
+
+		// This is the first whitespace token on a line
+		// and the line before this one is not empty,
+		// so this could be the start of a multiple empty line block.
+		$next = $phpcsFile->findNext( T_WHITESPACE, $stackPtr, null, true );
+		$lines = ( $tokens[ $next ]['line'] - $tokens[ $stackPtr ]['line'] );
+
+		// If there's only one whitespace line, this sniff does not apply.
+		if ( $lines <= 1 ) {
+			return;
+		}
+
+		// If the next non T_WHITESPACE token is more than 1 line away,
+		// then there were multiple empty lines.
+		$error = 'Multiple empty lines should not exist in a row; found %s consecutive empty lines';
+		$fix   = $phpcsFile->addFixableError(
+			$error,
+			$stackPtr,
+			'MultipleEmptyLines',
+			[ $lines ]
+		);
+
+		// Only continue if we're in fixing mode.
+		if ( $fix !== true ) {
+			return;
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+		$i = $stackPtr;
+		while ( $tokens[ $i ]['line'] !== $tokens[ $next ]['line'] ) {
+			$phpcsFile->fixer->replaceToken( $i, '' );
+			$i++;
+		}
+
+		$phpcsFile->fixer->addNewlineBefore( $i );
+		$phpcsFile->fixer->endChangeset();
 	}
 }

--- a/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
+++ b/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
@@ -23,15 +23,16 @@ class MultipleEmptyLinesSniff implements Sniff {
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		if ( $stackPtr > 2
-			&& $tokens[$stackPtr - 1]['line'] < $tokens[$stackPtr]['line']
-			&& $tokens[$stackPtr - 2]['line'] === $tokens[$stackPtr - 1]['line']
+		if (
+			$stackPtr > 2
+			&& $tokens[ $stackPtr - 1 ]['line'] < $tokens[ $stackPtr ]['line']
+			&& $tokens[ $stackPtr - 2 ]['line'] === $tokens[ $stackPtr - 1 ]['line']
 		) {
 			// This is the first whitespace token on a line
 			// and the line before this one is not empty,
 			// so this could be the start of a multiple empty line block.
 			$next = $phpcsFile->findNext( T_WHITESPACE, $stackPtr, null, true );
-			$lines = ( $tokens[$next]['line'] - $tokens[$stackPtr]['line'] );
+			$lines = ( $tokens[ $next ]['line'] - $tokens[ $stackPtr ]['line'] );
 
 			if ( $lines > 1 ) {
 				// If the next non T_WHITESPACE token is more than 1 line away,
@@ -41,13 +42,13 @@ class MultipleEmptyLinesSniff implements Sniff {
 					$error,
 					$stackPtr,
 					'MultipleEmptyLines',
-					array( $lines )
+					[ $lines ]
 				);
 
 				if ( $fix === true ) {
 					$phpcsFile->fixer->beginChangeset();
 					$i = $stackPtr;
-					while ( $tokens[$i]['line'] !== $tokens[$next]['line'] ) {
+					while ( $tokens[ $i ]['line'] !== $tokens[ $next ]['line'] ) {
 						$phpcsFile->fixer->replaceToken( $i, '' );
 						$i++;
 					}

--- a/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
+++ b/HM/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
@@ -16,10 +16,28 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class MultipleEmptyLinesSniff implements Sniff {
 
+	/**
+	 * Registers the tokens that this sniff wants to listen for.
+	 *
+	 * @return array
+	 * @see    Tokens.php
+	 */
 	public function register() {
 		return [ T_WHITESPACE ];
 	}
 
+	/**
+	 * Called when one of the token types that this sniff is listening for is found.
+	 *
+	 * The stackPtr variable indicates where in the stack the token was found.
+	 * A sniff can acquire information this token, along with all the other
+	 * tokens within the stack by first acquiring the token stack:
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the PHP_CodeSniffer file's token stack where the token was found.
+	 *
+	 * @return void
+	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 

--- a/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.fail
+++ b/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.fail
@@ -1,0 +1,27 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+
+use \HM\Other;
+use \WP_Post;
+
+function some_function( $some_argument ) {
+    $variable = 'some string';
+
+
+    return $variable;
+}
+
+class MyTest Class {
+
+
+    __construct() {
+        do_something();
+    }
+
+
+    public function another_function() {
+        return null;
+    }
+}

--- a/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.php
+++ b/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace HM\Tests\Whitespace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Class NoLeadingSlashOnUseUnitTest
+ *
+ * @group hm-sniffs
+ */
+class MultipleEmptyLinesUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		$file = func_get_arg( 0 );
+		switch ( $file ) {
+			case 'MultipleEmptyLinesUnitTest.success':
+				return [];
+
+			case 'MultipleEmptyLinesUnitTest.fail':
+				return [
+					4 => 1,
+					11 => 1,
+					17 => 1,
+					22 => 1,
+				];
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+
+}

--- a/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.php
+++ b/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.php
@@ -5,7 +5,7 @@ namespace HM\Tests\Whitespace;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Class NoLeadingSlashOnUseUnitTest
+ * Class MultipleEmptyLinesUnitTest
  *
  * @group hm-sniffs
  */

--- a/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.success
+++ b/HM/Tests/Whitespace/MultipleEmptyLinesUnitTest.success
@@ -1,0 +1,22 @@
+<?php
+
+namespace HM\Coding\Standards\Tests;
+
+use HM\Other;
+use WP_Post;
+
+function some_function( $some_argument ) {
+    $variable = 'some string';
+
+    return $variable;
+}
+
+class MyTest Class {
+    __construct() {
+        do_something();
+    }
+
+    public function another_function() {
+        return null;
+    }
+}

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -140,4 +140,9 @@
 	<!-- Ban inline assignment in control structures (see note on Yoda Conditions above). -->
 	<rule ref="PSR2R.ControlStructures.NoInlineAssignment" />
 
+	<!-- Our custom empty line rule handles superfluous whitespace better -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
+	</rule>
+
 </ruleset>

--- a/tests/fixtures/fail/consecutive-empty-lines.php
+++ b/tests/fixtures/fail/consecutive-empty-lines.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Consecutive empty lines should generate an error.
+ */
+
+
+function foo() {
+	$variable = 'something';
+
+
+	return $variable;
+}
+

--- a/tests/fixtures/fail/consecutive-empty-lines.php.json
+++ b/tests/fixtures/fail/consecutive-empty-lines.php.json
@@ -1,0 +1,20 @@
+{
+	"5": [
+		{
+			"source": "HM.Whitespace.MultipleEmptyLines.MultipleEmptyLines",
+			"type": "error"
+		}
+	],
+	"7": [
+		{
+			"source": "HM.Functions.NamespacedFunctions.MissingNamespace",
+			"type": "error"
+		}
+	],
+	"9": [
+		{
+			"source": "HM.Whitespace.MultipleEmptyLines.MultipleEmptyLines",
+			"type": "error"
+		}
+	]
+}


### PR DESCRIPTION
This PR copies in a rule to handles multiple empty lines all throughout PHP. I copied this rule in the MediaWiki ruleset as it felt unnecessary to include their whole ruleset for one very small rule and this is a particularly maintainable sniff. I am open to opinions on the approach.

This will detect any empty consecutive lines. It improves on the main Squiz rule as the Squiz rule only detects multiple lines within functions, and not in classes or in general PHP.

Fixes #60