### PR TITLE
Ignore at-rule line break for if/else/elseif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Updated
  - Bumped `stylelint-config-wordpress` package to v15 from v13 #165
+ - Ignore stylelint `at-rule` line break for `if/else/elseif` #170
 
 ## 0.7.0 (June 5, 2019)
 

--- a/packages/stylelint-config/.stylelintrc.json
+++ b/packages/stylelint-config/.stylelintrc.json
@@ -45,7 +45,8 @@
       "always",
       {
         "except": [ "blockless-after-blockless", "first-nested" ],
-        "ignore": [ "after-comment" ]
+        "ignore": [ "after-comment" ],
+        "ignoreAtRules": [ "if", "else if", "else" ]
       }
     ],
     "number-max-precision": 3


### PR DESCRIPTION
Fixes #160

Ignore `if`, `elseif` and `else` from the rule `at-rule-empty-line-before` to allow correct formatting of these statements. 