### PR TITLE
Update to phpcs 3.5.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Added `WordPress.Security.EscapeOutput` PHPCS rule #166
 
 ### Updated
+ - Bumped PHPCS to v3.5 from v3.4 #173
  - Bumped `stylelint-config-wordpress` package to v15 from v13 #165
  - Ignore stylelint `at-rule` line break for `if/else/elseif` #170
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"automattic/vipwpcs": "1.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
-		"squizlabs/php_codesniffer": "~3.4.0",
+		"squizlabs/php_codesniffer": "~3.5.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
3.4.* creates a lot of warnings with PHP 7.4. Switching this, everything looks to still work.