### PR TITLE
Include WordPress-Docs ruleset in PHPCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Added `WordPress.Security.EscapeOutput` PHPCS rule #166
  - Added PHPCompatibilityWP standard to PHPCS #81
  - Disallowed usage of `!important` in CSS #164
+ - Included `WordPress-Docs` by default in PHPCS #177
 
 ### Updated
  - Bumped `stylelint-config-wordpress` package to v15 from v13 #165

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -47,6 +47,9 @@
 		<exclude name="WordPress.PHP.YodaConditions" />
 	</rule>
 
+	<!-- Require proper docblocks be used in all PHP files -->
+	<rule ref="WordPress-Docs" />
+
 	<!-- Prefer alignment over line length. -->
 	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
 		<properties>


### PR DESCRIPTION
This includes the WordPress-Docs ruleset by default in PHPCS. 

Note that this has the potential to create a _lot_ of noise on existing projects and we should likely warn people when/if this is merged and deployed.

Fixes #167 