### PR TITLE
Make eslint-plugin-sort-destructure-keys eslint plugin available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Added PHPCompatibilityWP standard to PHPCS #81
  - Disallowed usage of `!important` in CSS #164
  - Enforced consistent curly newlines in jsx #172
+ - Added `eslint-plugin-sort-destructure-keys` package #179
 
 ### Updated
  - Bumped PHPCS to v3.5 from v3.4 #173

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -16,7 +16,8 @@
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-sort-destructure-keys": "^1.3.3"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
Following @mikeselander comment here: https://github.com/humanmade/linter-bot/pull/112, I need to replicate that PR here