### PR TITLE
Add better checks for meta queries

### DIFF
--- a/HM-Required/ruleset.xml
+++ b/HM-Required/ruleset.xml
@@ -22,6 +22,7 @@
 
 	<!-- Disallow slow database queries -->
 	<rule ref="HM.Performance.SlowMetaQuery" />
+	<rule ref="HM.Performance.SlowOrderBy" />
 
 	<!-- Require output is escaped. -->
 	<!-- Note: we use our version of EscapeOutput to ignore error-reporting functions. -->

--- a/HM-Required/ruleset.xml
+++ b/HM-Required/ruleset.xml
@@ -21,7 +21,7 @@
 	-->
 
 	<!-- Disallow slow database queries -->
-	<rule ref="WordPress.DB.SlowDBQuery" />
+	<rule ref="HM.Performance.SlowMetaQuery" />
 
 	<!-- Require output is escaped. -->
 	<!-- Note: we use our version of EscapeOutput to ignore error-reporting functions. -->

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -143,16 +143,8 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 				$compare = $default_compare;
 			}
 
-			if ( $compare !== 'EXISTS' && $compare !== 'NOT EXISTS' ) {
-				// Add a message ourselves.
-				$this->addMessage(
-					'meta_query is using %s comparison, which is non-performant.',
-					$this->stackPtr,
-					'warning',
-					'nonperformant_comparison',
-					[ $compare ]
-				);
-			}
+			// Add a message ourselves.
+			$this->check_compare_value( $compare );
 		}
 
 		// Disable the built-in warnings.
@@ -267,6 +259,24 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		}
 
 		return $indices;
+	}
+
+	/**
+	 * Add an error if the comparison isn't allowed.
+	 *
+	 * @param string $compare Comparison value
+	 */
+	protected function check_compare_value( string $compare ) : void {
+		if ( $compare !== 'EXISTS' && $compare !== 'NOT EXISTS' ) {
+			// Add a message ourselves.
+			$this->addMessage(
+				'meta_query is using %s comparison, which is non-performant.',
+				$this->stackPtr,
+				'warning',
+				'nonperformant_comparison',
+				[ $compare ]
+			);
+		}
 	}
 
 	/**

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -45,11 +45,9 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		return array(
 			'slow_query' => array(
 				'type'    => 'warning',
-				'message' => 'Detected non-performant usage of %s.',
+				'message' => 'Querying by %s is not performant.',
 				'keys'    => array(
-					'meta_compare',
 					'meta_query',
-					'meta_key',
 					'meta_value',
 				),
 			),

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -105,7 +105,13 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		}
 
 		// Get the array's bounds, then grab the indices.
-		$array_open = $this->phpcsFile->findNext( [ T_ARRAY, T_OPEN_SHORT_ARRAY ], $this->stackPtr );
+		$array_open = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA, T_CLOSE_SHORT_ARRAY ] ), $this->stackPtr + 1, null, true );
+		$array_open_token = $this->tokens[ $array_open ];
+		if ( $array_open_token['code'] !== T_ARRAY && $array_open_token['code'] !== T_OPEN_SHORT_ARRAY ) {
+			// Dynamic value, we can't check.
+			return true;
+		}
+
 		$array_bounds = $this->find_array_open_close( $array_open );
 		$elements = $this->get_array_indices( $array_bounds['opener'], $array_bounds['closer'] );
 

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -109,7 +109,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		$array_bounds = $this->find_array_open_close( $array_open );
 		$elements = $this->get_array_indices( $array_bounds['opener'], $array_bounds['closer'] );
 
-		$default_compare = $this->get_compare_from_array( $elements );
+		$default_compare = $this->get_static_value_from_array( $elements, 'compare' );
 		if ( empty( $default_compare ) ) {
 			// The default is either IN or = depending on whether value is
 			// set, but this only matters for the message.
@@ -132,7 +132,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 			$value_bounds = $this->find_array_open_close( $element['value_start'] );
 			$value_elements = $this->get_array_indices( $value_bounds['opener'], $value_bounds['closer'] );
-			$compare = $this->get_compare_from_array( $value_elements );
+			$compare = $this->get_static_value_from_array( $value_elements, 'compare' );
 			if ( empty( $compare ) ) {
 				$compare = $default_compare;
 			}
@@ -153,7 +153,14 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		return false;
 	}
 
-	protected function get_compare_from_array( array $elements ) : ?string {
+	/**
+	 * Get a static value from an array.
+	 *
+	 * @param array $elements Elements from the array (from get_array_indices())
+	 * @param string $array_key Key to find in the array.
+	 * @return string|null Static value if available, null otherwise.
+	 */
+	protected function get_static_value_from_array( array $elements, string $array_key ) : ?string {
 		foreach ( $elements as $element ) {
 			if ( ! isset( $element['index_start'] ) ) {
 				// Numeric item, skip.
@@ -174,8 +181,8 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			}
 
 			$index = $this->strip_quotes( $this->tokens[ $start ]['content'] );
-			if ( $index !== 'compare' ) {
-				// Not the compare function, skip.
+			if ( $index !== $array_key ) {
+				// Not the item we want, skip.
 				continue;
 			}
 

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace HM\Sniffs\Performance;
+
+// use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
+/**
+ * Flag potentially slow queries.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.12.0 Introduced new and more intuitively named 'slow query' whitelist
+ *                 comment, replacing the 'tax_query' whitelist comment which is now
+ *                 deprecated.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ */
+class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
+	/**
+	 * Current stack pointer.
+	 *
+	 * @var int
+	 */
+	protected $stackPtr;
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'slow_query' => array(
+				'type'    => 'warning',
+				'message' => 'Detected non-performant usage of %s.',
+				'keys'    => array(
+					'meta_compare',
+					'meta_query',
+					'meta_key',
+					'meta_value',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Process a token.
+	 *
+	 * Overrides the parent to store the stackPtr for later use.
+	 *
+	 * @param int $stackPtr
+	 */
+	public function process_token( $stackPtr ) {
+		$this->stackPtr = $stackPtr;
+		parent::process_token( $stackPtr );
+		unset( $this->stackPtr );
+	}
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		switch ( $key ) {
+			case 'meta_value':
+				// When meta_value is specified, the query operates on the value,
+				// and is hence expensive. (UNLESS: meta_compare is set)
+				return true;
+
+			case 'meta_query':
+				return $this->check_meta_query();
+
+			default:
+				// Unknown key, assume it's an error.
+				return true;
+		}
+	}
+
+	protected function check_meta_query() {
+		// Grab the token we're detecting.
+		$token = $this->tokens[ $this->stackPtr ];
+		if ( $token['code'] !== T_DOUBLE_ARROW ) {
+			var_dump( $token );
+			exit;
+		}
+
+		// Get the array's bounds, then grab the indices.
+		$array_open = $this->phpcsFile->findNext( [ T_ARRAY, T_OPEN_SHORT_ARRAY ], $this->stackPtr );
+		$array_bounds = $this->find_array_open_close( $array_open );
+		$elements = $this->get_array_indices( $array_bounds['opener'], $array_bounds['closer'] );
+
+		$default_compare = $this->get_compare_from_array( $elements );
+		foreach ( $elements as $element ) {
+			// Is this a named index?
+			if ( isset( $element['index_start'] ) ) {
+				// Skip it, already handled above.
+				continue;
+			}
+
+			// Numeric index, so this is a specific comparison. Explore the array.
+			$value_token = $this->tokens[ $element['value_start'] ];
+			if ( $value_token['code'] !== T_ARRAY && $value_token['code'] !== T_OPEN_SHORT_ARRAY ) {
+				// Invalid item in meta query.
+				continue;
+			}
+
+			$value_bounds = $this->find_array_open_close( $element['value_start'] );
+			$value_elements = $this->get_array_indices( $value_bounds['opener'], $value_bounds['closer'] );
+			$compare = $this->get_compare_from_array( $value_elements );
+			if ( empty( $compare ) ) {
+				$compare = $default_compare;
+			}
+
+			if ( $compare !== 'EXISTS' && $compare !== 'NOT EXISTS' ) {
+				// Add a message ourselves.
+				$this->addMessage(
+					'meta_query is using %s comparison, which is non-performant.',
+					$this->stackPtr,
+					'warning',
+					'nonperformant_comparison',
+					[ $compare ]
+				);
+			}
+		}
+
+		// Disable the built-in warnings.
+		return false;
+	}
+
+	protected function get_compare_from_array( array $elements ) : ?string {
+		foreach ( $elements as $element ) {
+			if ( ! isset( $element['index_start'] ) ) {
+				// Numeric item, skip.
+				continue;
+			}
+
+			// Ensure the index is a static string first.
+			$start = $element['index_start'];
+			if ( $this->tokens[ $start ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
+				// Dynamic key.
+				continue;
+			}
+
+			$maybe_index_end = $this->phpcsFile->findNext( Tokens::$emptyTokens, $start + 1, null, true );
+			if ( $this->tokens[ $maybe_index_end ]['code'] !== T_DOUBLE_ARROW ) {
+				var_dump( 'warning, invalid index' );
+				exit;
+			}
+
+			$index = $this->strip_quotes( $this->tokens[ $start ]['content'] );
+			if ( $index !== 'compare' ) {
+				// Not the compare function, skip.
+				continue;
+			}
+
+			// Got the compare, grab the value.
+			$value_start = $element['value_start'];
+			if ( $this->tokens[ $value_start ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
+				var_dump( 'dynamic value, error' );
+				continue;
+			}
+
+			$maybe_value_end = $this->phpcsFile->findNext( Tokens::$emptyTokens, $value_start + 1, null, true );
+			if ( $this->tokens[ $maybe_value_end ]['code'] !== T_COMMA ) {
+				var_dump( 'invalid value, error' );
+				continue;
+			}
+
+			return $this->strip_quotes( $this->tokens[ $value_start ]['content'] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get array indices information.
+	 *
+	 * @internal From phpcs' AbstractArraySniff::get_array_indices
+	 *
+	 * @param integer $array_start
+	 * @param integer $array_end
+	 * @return array
+	 */
+	protected function get_array_indices( int $array_start, int $array_end ) : array {
+		$indices = [];
+
+		$current = $array_start;
+		while ( ( $next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $current + 1 ), $array_end, true ) ) !== false ) {
+			$end = $this->get_next( $this->phpcsFile, $next, $array_end );
+
+			if ( $this->tokens[ $end ]['code'] === T_DOUBLE_ARROW ) {
+				$indexEnd = $this->phpcsFile->findPrevious( T_WHITESPACE, $end - 1, null, true );
+				$value_start = $this->phpcsFile->findNext( Tokens::$emptyTokens, $end + 1, null, true);
+
+				$indices[] = [
+					'index_start' => $next,
+					'index_end' => $indexEnd,
+					'arrow' => $end,
+					'value_start' => $value_start,
+				];
+			} else {
+				$value_start = $next;
+				$indices[] = [
+					'value_start' => $value_start,
+				];
+			}
+
+			$current = $this->get_next( $this->phpcsFile, $value_start, $array_end );
+		}
+
+		return $indices;
+	}
+
+	/**
+	 * Find next separator in array - either: comma or double arrow.
+	 *
+	 * @internal From phpcs' AbstractArraySniff::getNext
+	 *
+	 * @param File $phpcsFile The current file being checked.
+	 * @param int $ptr The position of current token.
+	 * @param int $arrayEnd The token that ends the array definition.
+	 *
+	 * @return int
+	 */
+	protected function get_next( File $phpcsFile, $ptr, $arrayEnd ) {
+		$tokens = $phpcsFile->getTokens();
+
+		while ($ptr < $arrayEnd) {
+			if (isset($tokens[$ptr]['scope_closer']) === true) {
+				$ptr = $tokens[$ptr]['scope_closer'];
+			} else if (isset($tokens[$ptr]['parenthesis_closer']) === true) {
+				$ptr = $tokens[$ptr]['parenthesis_closer'];
+			} else if (isset($tokens[$ptr]['bracket_closer']) === true) {
+				$ptr = $tokens[$ptr]['bracket_closer'];
+			}
+
+			if ($tokens[$ptr]['code'] === T_COMMA
+				|| $tokens[$ptr]['code'] === T_DOUBLE_ARROW
+			) {
+				return $ptr;
+			}
+
+			++$ptr;
+		}
+
+		return $ptr;
+	}
+}

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -1,32 +1,13 @@
 <?php
-/**
- * WordPress Coding Standard.
- *
- * @package WPCS\WordPressCodingStandards
- * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace HM\Sniffs\Performance;
 
-// use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 
 /**
- * Flag potentially slow queries.
- *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
- *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.12.0 Introduced new and more intuitively named 'slow query' whitelist
- *                 comment, replacing the 'tax_query' whitelist comment which is now
- *                 deprecated.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ * Flag slow meta queries.
  */
 class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -122,7 +122,13 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		$array_open_token = $this->tokens[ $array_open ];
 		if ( $array_open_token['code'] !== T_ARRAY && $array_open_token['code'] !== T_OPEN_SHORT_ARRAY ) {
 			// Dynamic value, we can't check.
-			// TODO: error.
+			$this->addMessage(
+				'meta_query is dynamic, cannot be checked.',
+				$array_open,
+				'warning',
+				'dynamic_query'
+			);
+
 			return;
 		}
 

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -110,6 +110,12 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		$elements = $this->get_array_indices( $array_bounds['opener'], $array_bounds['closer'] );
 
 		$default_compare = $this->get_compare_from_array( $elements );
+		if ( empty( $default_compare ) ) {
+			// The default is either IN or = depending on whether value is
+			// set, but this only matters for the message.
+			$default_compare = 'default';
+		}
+
 		foreach ( $elements as $element ) {
 			// Is this a named index?
 			if ( isset( $element['index_start'] ) ) {

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -86,10 +86,6 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 	protected function check_meta_query() {
 		// Grab the token we're detecting.
 		$token = $this->tokens[ $this->stackPtr ];
-		if ( $token['code'] !== T_DOUBLE_ARROW ) {
-			var_dump( $token );
-			exit;
-		}
 
 		// Find the value of meta_query, and check it.
 		$array_open = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA, T_CLOSE_SHORT_ARRAY ] ), $this->stackPtr + 1, null, true );
@@ -201,7 +197,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			$maybe_index_end = $this->phpcsFile->findNext( Tokens::$emptyTokens, $start + 1, null, true );
 			if ( $this->tokens[ $maybe_index_end ]['code'] !== T_DOUBLE_ARROW ) {
 				// Dynamic key, maybe? This is probably not valid syntax.
-				exit;
+				continue;
 			}
 
 			$index = $this->strip_quotes( $this->tokens[ $start ]['content'] );

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -297,18 +297,16 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 	protected function get_next( File $phpcsFile, $ptr, $arrayEnd ) {
 		$tokens = $phpcsFile->getTokens();
 
-		while ($ptr < $arrayEnd) {
-			if (isset($tokens[$ptr]['scope_closer']) === true) {
-				$ptr = $tokens[$ptr]['scope_closer'];
-			} else if (isset($tokens[$ptr]['parenthesis_closer']) === true) {
-				$ptr = $tokens[$ptr]['parenthesis_closer'];
-			} else if (isset($tokens[$ptr]['bracket_closer']) === true) {
-				$ptr = $tokens[$ptr]['bracket_closer'];
+		while ( $ptr < $arrayEnd ) {
+			if ( isset( $tokens[ $ptr ]['scope_closer']) === true ) {
+				$ptr = $tokens[ $ptr ]['scope_closer'];
+			} elseif ( isset( $tokens[ $ptr ]['parenthesis_closer'] ) === true ) {
+				$ptr = $tokens[ $ptr ]['parenthesis_closer'];
+			} elseif ( isset( $tokens[ $ptr ]['bracket_closer'] ) === true ) {
+				$ptr = $tokens[ $ptr ]['bracket_closer'];
 			}
 
-			if ($tokens[$ptr]['code'] === T_COMMA
-				|| $tokens[$ptr]['code'] === T_DOUBLE_ARROW
-			) {
+			if ( $tokens[ $ptr ]['code'] === T_COMMA || $tokens[ $ptr ]['code'] === T_DOUBLE_ARROW ) {
 				return $ptr;
 			}
 

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -182,7 +182,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 			$maybe_index_end = $this->phpcsFile->findNext( Tokens::$emptyTokens, $start + 1, null, true );
 			if ( $this->tokens[ $maybe_index_end ]['code'] !== T_DOUBLE_ARROW ) {
-				var_dump( 'warning, invalid index' );
+				// Dynamic key, maybe? This is probably not valid syntax.
 				exit;
 			}
 
@@ -195,7 +195,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			// Got the compare, grab the value.
 			$value_start = $element['value_start'];
 			if ( $this->tokens[ $value_start ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
-				var_dump( 'dynamic value, error' );
+				// Dynamic value, skip.
 				continue;
 			}
 

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -115,19 +115,19 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		$array_bounds = $this->find_array_open_close( $array_open );
 		$elements = $this->get_array_indices( $array_bounds['opener'], $array_bounds['closer'] );
 
-		$default_compare = $this->get_static_value_from_array( $elements, 'compare' );
-		if ( empty( $default_compare ) ) {
-			// The default is either IN or = depending on whether value is
-			// set, but this only matters for the message.
-			$default_compare = 'default';
-		}
-
 		// Is this a "first-order" query?
 		// @see WP_Meta_Query::is_first_order_clause
 		$first_order_key = $this->find_key_in_array( $elements, 'key' );
 		$first_order_value = $this->find_key_in_array( $elements, 'value' );
 		if ( $first_order_key || $first_order_value  ) {
-			$this->check_compare_value( $default_compare );
+			$compare = $this->get_static_value_from_array( $elements, 'compare' );
+			if ( empty( $compare ) ) {
+				// The default is either IN or = depending on whether value is
+				// set, but this only matters for the message.
+				$compare = 'default';
+			}
+
+			$this->check_compare_value( $compare );
 
 			// Disable any built-in warnings.
 			return false;
@@ -151,7 +151,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			$value_elements = $this->get_array_indices( $value_bounds['opener'], $value_bounds['closer'] );
 			$compare = $this->get_static_value_from_array( $value_elements, 'compare' );
 			if ( empty( $compare ) ) {
-				$compare = $default_compare;
+				$compare = 'default';
 			}
 
 			// Add a message ourselves.

--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -122,6 +122,17 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			$default_compare = 'default';
 		}
 
+		// Is this a "first-order" query?
+		// @see WP_Meta_Query::is_first_order_clause
+		$first_order_key = $this->find_key_in_array( $elements, 'key' );
+		$first_order_value = $this->find_key_in_array( $elements, 'value' );
+		if ( $first_order_key || $first_order_value  ) {
+			$this->check_compare_value( $default_compare );
+
+			// Disable any built-in warnings.
+			return false;
+		}
+
 		foreach ( $elements as $element ) {
 			// Is this a named index?
 			if ( isset( $element['index_start'] ) ) {

--- a/HM/Sniffs/Performance/SlowOrderBySniff.php
+++ b/HM/Sniffs/Performance/SlowOrderBySniff.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace HM\Sniffs\Performance;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
+/**
+ * Flag slow orderby usage in WP queries.
+ */
+class SlowOrderBySniff extends AbstractArrayAssignmentRestrictionsSniff {
+	/**
+	 * Current stack pointer.
+	 *
+	 * @var int
+	 */
+	protected $stackPtr;
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'slow_order' => array(
+				'type'    => 'warning',
+				'message' => 'Ordering query results by %s is not performant.',
+				'keys'    => array(
+					'orderby',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Process a token.
+	 *
+	 * Overrides the parent to store the stackPtr for later use.
+	 *
+	 * @param int $stackPtr
+	 */
+	public function process_token( $stackPtr ) {
+		$this->stackPtr = $stackPtr;
+		parent::process_token( $stackPtr );
+		unset( $this->stackPtr );
+	}
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		switch ( $val ) {
+			case 'rand':
+			case 'meta_value':
+			case 'meta_value_num':
+				// Dynamic value, we can't check.
+				$this->addMessage(
+					'Ordering query results by %s is not performant.',
+					$this->stackPtr,
+					'warning',
+					'slow_order',
+					[ $val ]
+				);
+
+				// Skip built-in message.
+				return false;
+
+			default:
+				// No match.
+				return false;
+		}
+	}
+}


### PR DESCRIPTION
This replaces the blanket rule in WPCS for any meta query with something a lot smarter, allowing any meta queries which are using `EXISTS` or `NOT EXISTS` queries.

It also disallows the use of `meta_value`, `meta_value_num`, and `rand` in `orderby`.