### PR TITLE
Show colors and rule names in the report

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -7,6 +7,8 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 
+	<arg name="colors"/>
+	<arg value="s"/>
 	<arg name="basepath" value="." />
 	<arg name="extensions" value="php" />
 


### PR DESCRIPTION
When running `phpcs`, the summary report looks ugly and doesn't show any information about the rules that are not passing. This commit helps to:
- Use some colors in the terminal
- Display, for every rule that is not passing, the name of the rule to help to identify what's really going on.

Here's a sample:

**Before**
<img width="1168" alt="Captura de pantalla 2020-03-25 a las 11 19 49" src="https://user-images.githubusercontent.com/1516569/77526712-4f68d000-6e8b-11ea-9e94-8a7306fe1d4e.png">

**After**
<img width="1244" alt="Captura de pantalla 2020-03-25 a las 11 19 39" src="https://user-images.githubusercontent.com/1516569/77526744-5b549200-6e8b-11ea-81d6-5dcfc9a992e1.png">



