### PR TITLE
Remove Default `<file>` and `<basepath>` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## Unreleased (1.0.0)
 
-### Added
+### Added:
  - Included `WordPress-Docs` by default in PHPCS #177
  - Add ESLint rule for JSX boolean values #183
 
-### Updated
+### Updated:
  - Updated WPCS to 2.2.1 #151
  - Updated VIPCS to 2.0.0 #151
  - Updated DealerDirect to 0.6 #151
+
+### Removed:
+ - Remove `<file>` and `<basepath>` from ruleset #187
 
 ##  0.8.0 (January 29, 2020)
 

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -2,8 +2,6 @@
 <ruleset name="HM">
 	<description>Human Made coding standards.</description>
 
-	<file>.</file>
-
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -5,7 +5,6 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 
-	<arg name="basepath" value="." />
 	<arg name="extensions" value="php" />
 
 	<autoload>bootstrap.php</autoload>


### PR DESCRIPTION
This PR fixes several issues related to the defaults set in the HM ruleset that define the basepath and main files. These provide easy defaults, but can cause issues in several cases which make our rules unusable.

 - Removing `<basepath>`: This value was preventing Visual Studio Code PHPCS extensions from using our ruleset. See #184
 - Removing `<file>`: This value was preventing projects from creating an "inclusion" list, forcing them to instead build a "disallow" list instead which is untenable for some projects. See #159

I feel comfortable forcing projects to set these values as they need since PHPCS should really only be setup once on a project.

Paging @jrfnl and @ntwb - do you see any problem with removing these values I might have missed?