### PR TITLE
Disallow `use function` and `use const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
  - Included `WordPress-Docs` by default in PHPCS #177
  - Add ESLint rule for JSX boolean values #183
- - Disallow `use function` #188
+ - Disallow `use function` and `use const` #188
 
 ### Updated
  - Updated WPCS to 2.2.1 #151

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
  - Included `WordPress-Docs` by default in PHPCS #177
  - Add ESLint rule for JSX boolean values #183
+ - Disallow `use function` #188
 
 ### Updated
  - Updated WPCS to 2.2.1 #151

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -156,4 +156,6 @@
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
 	</rule>
 
+	<!-- Disallow usage of `use function`, while still allowing `use` and `use const` -->
+	<rule ref="Universal.UseStatements.DisallowUseFunction" />
 </ruleset>

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -156,6 +156,7 @@
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
 	</rule>
 
-	<!-- Disallow usage of `use function`, while still allowing `use` and `use const` -->
+	<!-- Disallow usage of `use function`, while still allowing `use`ing os namespaces -->
 	<rule ref="Universal.UseStatements.DisallowUseFunction" />
+	<rule ref="Universal.UseStatements.DisallowUseConst" />
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,8 @@
 	"description": "Human Made coding standards",
 	"type": "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"require": {
 		"php": ">=7.1",
 		"wp-coding-standards/wpcs": "2.2.1",
@@ -10,7 +12,8 @@
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"squizlabs/php_codesniffer": "~3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0",
+		"phpcsstandards/phpcsextra": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"


### PR DESCRIPTION
This addition disallows developers from using functions, while keeping the ability to `use` namespaces and constants. 

Special thanks to @jrfnl for building this ruleset for us and making this so easy to use!