### PR TITLE
Add React sorting props rule

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -105,6 +105,7 @@ module.exports = {
 			'singleline': 'consistent',
 		} ],
 		'react/jsx-boolean-value': [ 'error', 'never' ],
+		'react/jsx-sort-props': [ 'error' ],
 		'jsx-a11y/anchor-is-valid': [ 'error' ],
 	},
 };

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -105,7 +105,10 @@ module.exports = {
 			'singleline': 'consistent',
 		} ],
 		'react/jsx-boolean-value': [ 'error', 'never' ],
-		'react/jsx-sort-props': [ 'error' ],
+		'react/jsx-sort-props': [ 'error', {
+			'reservedFirst': [ 'key', 'ref' ],
+			'callbacksLast': true,
+		} ],
 		'jsx-a11y/anchor-is-valid': [ 'error' ],
 	},
 };

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -105,7 +105,7 @@ module.exports = {
 			'singleline': 'consistent',
 		} ],
 		'react/jsx-boolean-value': [ 'error', 'never' ],
-		'react/jsx-sort-props': [ 'error', {
+		'react/jsx-sort-props': [ 'warn', {
 			'reservedFirst': [ 'key', 'ref' ],
 			'callbacksLast': true,
 		} ],


### PR DESCRIPTION
Based on https://github.com/humanmade/coding-standards/issues/75 conversation, this PR adds a new rule to force the React components props to be sorted alphabetically