### PR TITLE
Add ESLInt Rules of Hooks ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Included `WordPress-Docs` by default in PHPCS #177
  - Add ESLint rule for JSX boolean values #183
  - Add ESLint rule for sorting JSX props #195  
+ - Add ESLInt Rules of Hooks ruleset #197
 
 ### Updated:
  - Updated WPCS to 2.2.1 #151

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -7,6 +7,7 @@ module.exports = {
 	'extends': [
 		'eslint:recommended',
 		'react-app',
+		'plugin:react-hooks/recommended',
 	],
 	'parserOptions': {
 		'ecmaVersion': 2018,

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-sort-destructure-keys": "^1.3.3"
   },
   "peerDependencies": {
@@ -26,7 +26,7 @@
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.14.3"
   },
   "files": [
     ".eslintrc",

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -17,6 +17,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^4.0.2",
     "eslint-plugin-sort-destructure-keys": "^1.3.3"
   },
   "peerDependencies": {
@@ -26,7 +27,8 @@
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.14.3"
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^4.0.2"
   },
   "files": [
     ".eslintrc",


### PR DESCRIPTION
Adds the React Hooks eslin plugin, as well as pegging the general React rules at a higher version.

Fixes #189
Fixes #194 