### PR TITLE
Remove Final PHPCS settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
  - Updated DealerDirect to 0.6 #151
 
 ### Removed:
- - Remove `<file>` and `<basepath>` from ruleset #187
+ - Remove `<file>`, `<basepath>` and `testVersion` from ruleset #187, #198
 
 ##  0.8.0 (January 29, 2020)
 

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -5,6 +5,8 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 
+	<arg name="extensions" value="php" />
+
 	<autoload>bootstrap.php</autoload>
 
 	<!-- Check for PHP cross-version compatibility. -->

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -5,12 +5,9 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 
-	<arg name="extensions" value="php" />
-
 	<autoload>bootstrap.php</autoload>
 
 	<!-- Check for PHP cross-version compatibility. -->
-	<config name="testVersion" value="7.1-" />
 	<rule ref="PHPCompatibilityWP" />
 
 	<rule ref="WordPress-Core">

--- a/readme.md
+++ b/readme.md
@@ -80,17 +80,17 @@ If you want to add further rules (such as WordPress.com VIP-specific rules) or c
 ```xml
 <?xml version="1.0"?>
 <ruleset>
-    <!-- Files or directories to check -->
-    <file>.</file>
+	<!-- Files or directories to check -->
+	<file>.</file>
 
-    <!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
-    <arg name="basepath" value="." />
+	<!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
+	<arg name="basepath" value="." />
 
-    <!-- Only parse PHP files -->
-    <arg name="extensions" value="php" />
+	<!-- Only parse PHP files -->
+	<arg name="extensions" value="php" />
 
-    <!-- Set a minimum PHP version for PHPCompatibility -->
-    <config name="testVersion" value="7.2-" />
+	<!-- Set a minimum PHP version for PHPCompatibility -->
+	<config name="testVersion" value="7.2-" />
 
 	<!-- Use HM Coding Standards -->
 	<rule ref="vendor/humanmade/coding-standards" />

--- a/readme.md
+++ b/readme.md
@@ -86,9 +86,6 @@ If you want to add further rules (such as WordPress.com VIP-specific rules) or c
 	<!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
 	<arg name="basepath" value="." />
 
-	<!-- Only parse PHP files -->
-	<arg name="extensions" value="php" />
-
 	<!-- Set a minimum PHP version for PHPCompatibility -->
 	<config name="testVersion" value="7.2-" />
 

--- a/readme.md
+++ b/readme.md
@@ -75,11 +75,23 @@ Patterns are relative to the directory that the `.phpcsignore` file lives in. On
 
 ### Advanced/Extending
 
-If you want to add further rules (such as WordPress.com VIP-specific rules), you can create your own custom standard file (e.g. `phpcs.ruleset.xml`):
+If you want to add further rules (such as WordPress.com VIP-specific rules) or customize PHPCS defaults, you can create your own custom standard file (e.g. `phpcs.ruleset.xml`):
 
 ```xml
 <?xml version="1.0"?>
 <ruleset>
+    <!-- Files or directories to check -->
+    <file>.</file>
+
+    <!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
+    <arg name="basepath" value="." />
+
+    <!-- Only parse PHP files -->
+    <arg name="extensions" value="php" />
+
+    <!-- Set a minimum PHP version for PHPCompatibility -->
+    <config name="testVersion" value="7.2-" />
+
 	<!-- Use HM Coding Standards -->
 	<rule ref="vendor/humanmade/coding-standards" />
 


### PR DESCRIPTION
Removing the last of the PHPCS settings that were preventing projects from setting their own values effectively. This makes our ruleset a more effective Standard in that we're no longer making assumptions for end users.

Also added examples of the values that may be set  per-project to the readme.

Resolves #191