### PR TITLE
Adjust Stylelint class and ID selector patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Add ESLint rule for sorting JSX props #195  
 
 ### Updated:
+ - Adjust Stylelint class and ID selector patterns #199
  - Updated WPCS to 2.2.1 #151
  - Updated VIPCS to 2.0.0 #151
  - Updated DealerDirect to 0.6 #151

--- a/packages/stylelint-config/.stylelintrc.json
+++ b/packages/stylelint-config/.stylelintrc.json
@@ -51,7 +51,7 @@
       }
     ],
     "number-max-precision": 3,
-    "selector-class-pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\\\[.+\\\\])?$",
+    "selector-class-pattern": "^(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$",
     "selector-id-pattern": null
   }
 }

--- a/packages/stylelint-config/.stylelintrc.json
+++ b/packages/stylelint-config/.stylelintrc.json
@@ -50,6 +50,8 @@
         "ignoreAtRules": [ "if", "else if", "else" ]
       }
     ],
-    "number-max-precision": 3
+    "number-max-precision": 3,
+    "selector-class-pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\\\[.+\\\\])?$",
+    "selector-id-pattern": null
   }
 }

--- a/packages/stylelint-config/.stylelintrc.json
+++ b/packages/stylelint-config/.stylelintrc.json
@@ -51,7 +51,12 @@
       }
     ],
     "number-max-precision": 3,
-    "selector-class-pattern": "^(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$",
+    "selector-class-pattern": [
+      "^(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$",
+      {
+        "resolveNestedSelectors": true
+      }
+    ],
     "selector-id-pattern": null
   }
 }


### PR DESCRIPTION
As mentioned in #193, the WordPress `selector-class pattern` does not allow for BEM, and the ID pattern is also unnecessarily restrictive.

This PR:
 - Modifies the `selector-class-pattern` rule to require BEM-type naming. See examples below.
 - Removes the `selector-id-pattern` rule as we have no standard for naming ID.

cc @humanmade/frontend 

Passes:
```css
.something {}
.some-class {}
.anything-else__and--other-things {}
.blocky-mc-block-face {}
.block__element {}
.block__element--modifier {}
.long-block__long-element--long-modifier {}
```

Errors:
```css
.block__element__element {}
.block__element--modifier--modifier {}
.block--modifier--modifier {}
.block--modifier__element {}
```

You can play around with these examples here: https://regex101.com/r/pH8CMO/1

Fixes #193