### PR TITLE
Turn off ContentAfterOpenBracket and CloseBracketLine for phpcbf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Updated WPCS to 2.2.1 #151
  - Updated VIPCS to 2.0.0 #151
  - Updated DealerDirect to 0.6 #151
+ - Fix FunctionCallSignature inconsistency in phpcbf #200
 
 ### Removed:
  - Remove `<file>` and `<basepath>` from ruleset #187

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -111,10 +111,10 @@
 		</properties>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-		<severity phpcs-only="true">0</severity>
+		<severity>0</severity>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-		<severity phpcs-only="true">0</severity>
+		<severity>0</severity>
 	</rule>
 
 	<!--


### PR DESCRIPTION
In 5e3e9eb2bc0ce0d99b469cd94d23f3bcaa66ea98, I re-allowed multiple arguments on a line after a WPCS change, but in my copy-🍝, I only fixed this for PHPCS, and not PHPCBF. This fixes #62 by adjusting this in all places.

You can test this by adding `example.php` locally (see below) and running `vendor/bin/phpcbf --standard=HM/ruleset.xml example.php`. The code should remain unchanged.

```php
<?php
add_filter( 'determine_current_user', function ( $user ) {
	return 1;
} );

```