### PR TITLE
Allow for multiple variable assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Updated WPCS to 2.2.1 #151
  - Updated VIPCS to 2.0.0 #151
  - Updated DealerDirect to 0.6 #151
+ - Allow for multiple variable assignments #201
 
 ### Removed:
  - Remove `<file>` and `<basepath>` from ruleset #187

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -153,4 +153,9 @@
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
 	</rule>
 
+	<!-- Allow multiple variable assignments, but only outside of conditionals -->
+	<rule ref="Squiz.PHP.DisallowMultipleAssignments">
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
Allows us to assign multiple variables in a row.

To test, run `vendor/bin/phpcbf --standard=HM/ruleset.xml example.php` against the following `example.php` file locally.

```php
<?php

$foo = $bar = 'thing';

if ( $foo = get_me_something() ) {
	return false;
}
```

The first inline assignment should pass, and the inline conditional should still flag errors.

Note that the inline conditional assignment triggers several errors, but I personally don't mind a little bit of extra harassment for that sin 😄 

Fixes #69 