### PR TITLE
Allow for theme filenames when sniffing filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - Updated DealerDirect to 0.6 #151
  - Fix FunctionCallSignature inconsistency in phpcbf #200
  - Allow for multiple variable assignments #201
+ - Allow for theme filenames when sniffing filename #202
 
 ### Removed:
  - Remove `<file>`, `<basepath>` and `testVersion` from ruleset #187, #198

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -97,6 +97,13 @@
 
 	<rule ref="WordPress.DateTime.RestrictedFunctions" />
 
+	<!-- Allow for underscores in theme template file names -->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="is_theme" value="true" />
+		</properties>
+	</rule>
+
 	<!--
 	Restore the ability to have multiple arguments per line
 


### PR DESCRIPTION
Allows for theme-specific filenames with underscores in them.

Fixes #55 
