### PR TITLE
Do not enforce comma-dangle for function arguments

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -25,7 +25,13 @@ module.exports = {
 		} ],
 		'block-spacing': [ 'error' ],
 		'brace-style': [ 'error', '1tbs' ],
-		'comma-dangle': [ 'error', 'always-multiline' ],
+		'comma-dangle': [ 'error', {
+			'arrays': 'always-multiline',
+			'objects': 'always-multiline',
+			'imports': 'always-multiline',
+			'exports': 'always-multiline',
+			'functions': 'never',
+		} ],
 		'comma-spacing': [ 'error', {
 			'before': false,
 			'after': true,


### PR DESCRIPTION
Our current rules enforce comma-dangle globally, which includes function arguments despite that not being standard in JavaScript (and an error in most versions of PHP). I propose we adapt our config for this rule to only require/apply the comma for non-function multiline situations.