### PR TITLE
Ignore the full stop rules for comments

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -52,7 +52,9 @@
 
 	<!-- Require proper docblocks be used in all PHP files -->
 	<rule ref="WordPress-Docs">
-		 <exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
 	</rule>
 
 	<!-- Prefer alignment over line length. -->


### PR DESCRIPTION
The full stop flags in the Docs ruleset is nice for consistency, but generates a huge amount of noise and is generally has not other use. Removing it here to avoid the pain when people install 1.0