### PR TITLE
Require JSDoc for functions other than anonymous arrows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added:
  - Included `WordPress-Docs` by default in PHPCS #177
+ - Add ESLint rule for requiring docblocks #209
  - Add ESLint rule for JSX boolean values #183
  - Add ESLint rule for sorting JSX props #195  
  - Add ESLInt Rules of Hooks ruleset #197

--- a/packages/eslint-config-humanmade/fixtures/fail/component-jsx-parentheses.js
+++ b/packages/eslint-config-humanmade/fixtures/fail/component-jsx-parentheses.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import React from 'react';
 
 const World = () => <span>World</span>;

--- a/packages/eslint-config-humanmade/fixtures/fail/jsx-boolean-value.jsx
+++ b/packages/eslint-config-humanmade/fixtures/fail/jsx-boolean-value.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable no-unused-vars */
 
 import React from 'react';

--- a/packages/eslint-config-humanmade/fixtures/fail/jsx-curly-newline.jsx
+++ b/packages/eslint-config-humanmade/fixtures/fail/jsx-curly-newline.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable no-unused-vars */
 
 import React from 'react';

--- a/packages/eslint-config-humanmade/fixtures/fail/semicolon.js
+++ b/packages/eslint-config-humanmade/fixtures/fail/semicolon.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable no-unused-vars */
 
 // Missing semicolon.

--- a/packages/eslint-config-humanmade/fixtures/fail/variable-declaration.js
+++ b/packages/eslint-config-humanmade/fixtures/fail/variable-declaration.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 let obj = [ 'only assigned once' ];
 
 var str = 'default value';

--- a/packages/eslint-config-humanmade/fixtures/pass/component-jsx-parentheses.jsx
+++ b/packages/eslint-config-humanmade/fixtures/pass/component-jsx-parentheses.jsx
@@ -18,7 +18,6 @@ const Hello = () => (
  * Test class.
  */
 export default class Test extends React.Component {
-	/** @returns {React.ReactNode} Rendered component. */
 	render() {
 		return (
 			<div>

--- a/packages/eslint-config-humanmade/fixtures/pass/component-jsx-parentheses.jsx
+++ b/packages/eslint-config-humanmade/fixtures/pass/component-jsx-parentheses.jsx
@@ -1,14 +1,24 @@
 import React from 'react';
 
+/**
+ * @returns {React.ReactNode} Rendered <World> component.
+ */
 const World = () => <span>World</span>;
 
+/**
+ * @returns {React.ReactNode} Rendered <Hello> component.
+ */
 const Hello = () => (
 	<div>
 		<p>Hello <World /></p>
 	</div>
 );
 
+/**
+ * Test class.
+ */
 export default class Test extends React.Component {
+	/** @returns {React.ReactNode} Rendered component. */
 	render() {
 		return (
 			<div>

--- a/packages/eslint-config-humanmade/fixtures/pass/jsdoc-inline-arrow.js
+++ b/packages/eslint-config-humanmade/fixtures/pass/jsdoc-inline-arrow.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-unused-vars */
+
+const result = [].map( val => val.subval );
+
+const filteredThing = []
+	.filter( item => item.isIncludedInSet )
+	.reduce( ( sum, item ) => ( sum + item.immenseValue ), 0 );

--- a/packages/eslint-config-humanmade/fixtures/pass/jsx-boolean-value.jsx
+++ b/packages/eslint-config-humanmade/fixtures/pass/jsx-boolean-value.jsx
@@ -2,6 +2,9 @@
 
 import React from 'react';
 
+/**
+ * @returns {React.ReactNode} Rendered <A> component.
+ */
 const A = () => (
 	<div foo />
 );

--- a/packages/eslint-config-humanmade/fixtures/pass/jsx-curly-newline.jsx
+++ b/packages/eslint-config-humanmade/fixtures/pass/jsx-curly-newline.jsx
@@ -5,12 +5,18 @@ import React from 'react';
 const foo = 'foo';
 const bar = 'bar';
 
+/**
+ * @returns {React.ReactNode} Rendered <A> component.
+ */
 const A = () => (
 	<div>
 		{ foo }
 	</div>
 );
 
+/**
+ * @returns {React.ReactNode} Rendered <B> component.
+ */
 const B = () => (
 	<div>
 		{
@@ -19,6 +25,9 @@ const B = () => (
 	</div>
 );
 
+/**
+ * @returns {React.ReactNode} Rendered <C> component.
+ */
 const C = () => (
 	<div>
 		{ foo && (

--- a/packages/eslint-config-humanmade/fixtures/pass/semicolon.js
+++ b/packages/eslint-config-humanmade/fixtures/pass/semicolon.js
@@ -6,6 +6,7 @@ const testMissingSemicolon = 'foo';
 // Double semicolon.
 const testDoubleSemiColon = 5;
 
+/** */
 const testFunc = function () {
 	// ...
 };

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -6,8 +6,8 @@ module.exports = {
 	},
 	'extends': [
 		'eslint:recommended',
-		'jsdoc/recommended',
 		'react-app',
+		'plugin:jsdoc/recommended',
 		'plugin:react-hooks/recommended',
 	],
 	'parserOptions': {

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -6,6 +6,7 @@ module.exports = {
 	},
 	'extends': [
 		'eslint:recommended',
+		'jsdoc/recommended',
 		'react-app',
 		'plugin:react-hooks/recommended',
 	],
@@ -101,7 +102,8 @@ module.exports = {
 				'!': true,
 			},
 		} ],
-		'require-jsdoc': [ 'error', {
+		'yoda': [ 'error', 'never' ],
+		'jsdoc/require-jsdoc': [ 'error', {
 			'require': {
 				'FunctionDeclaration': true,
 				'MethodDefinition': true,
@@ -110,7 +112,6 @@ module.exports = {
 				'FunctionExpression': true,
 			},
 		} ],
-		'yoda': [ 'error', 'never' ],
 		'react/jsx-curly-spacing': [ 'error', {
 			'when': 'always',
 			'children': true,

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -106,7 +106,6 @@ module.exports = {
 		'jsdoc/require-jsdoc': [ 'error', {
 			'require': {
 				'FunctionDeclaration': true,
-				'MethodDefinition': true,
 				'ClassDeclaration': true,
 				'ArrowFunctionExpression': true,
 				'FunctionExpression': true,

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -101,6 +101,15 @@ module.exports = {
 				'!': true,
 			},
 		} ],
+		'require-jsdoc': [ 'error', {
+			'require': {
+				'FunctionDeclaration': true,
+				'MethodDefinition': true,
+				'ClassDeclaration': true,
+				'ArrowFunctionExpression': true,
+				'FunctionExpression': true,
+			},
+		} ],
 		'yoda': [ 'error', 'never' ],
 		'react/jsx-curly-spacing': [ 'error', {
 			'when': 'always',

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -15,6 +15,7 @@
     "eslint-config-react-app": "^3.0.5",
     "eslint-plugin-flowtype": "^3.2.0",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsdoc": "^29.1.3",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^4.0.2",


### PR DESCRIPTION
Per https://eslint.org/docs/rules/require-jsdoc this set of options appears to implement what was discussed in #157. Anonymous arrows are excluded from JSDoc requirements, while classes, function declarations, and methods all require documentation.

Fixes #157.