### PR TITLE
Limit Travis runs to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache:
     - $HOME/.npm
     - node_modules
 
+branches:
+  only:
+    - master
+
 # Test in modern and recent versions of PHP & Node.
 # Run each code style tool in containers specific to that tool's language.
 jobs:


### PR DESCRIPTION
We've been running Travis builds twice on PRs which is unnecessary, slow, and wastes potential concurrency on HM's Travis account. This limits branch runs to only run on master, and makes it so that runs only happen once on PRs.