### PR TITLE
Make JSX props sorting case-insensitive

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -124,6 +124,7 @@ module.exports = {
 		'react/jsx-sort-props': [ 'warn', {
 			'reservedFirst': [ 'key', 'ref' ],
 			'callbacksLast': true,
+			'ignoreCase': true,
 		} ],
 		'jsx-a11y/anchor-is-valid': [ 'error' ],
 	},


### PR DESCRIPTION
When using the **full** `HM` ESLint coding standards ruleset, you have to sort props on any JSX element, or you will see a warning. This is great, I love it!

The PR where this was introduced is #195.

And the current version still has the rule just like in the PR:

https://github.com/humanmade/coding-standards/blob/229b6e932ac8a0468b385a44c2836ae6f77ac0e6/packages/eslint-config-humanmade/index.js#L124-L127

One thing that is odd with this, which is simply because of the default behavior of the `react/jsx-sort-props` rule, is that it is **case-sensitive**, meaning uppercase letters come before lowercase ones.

This means that I have to sort props like so:

```js
    <Foo
        solutionType={ solutionType }
        solutions={ solutions }
    />
```

This feels unnatural to me, and changing this is can be done by setting an existing config value.

This PR does just that. 💥 😅