### PR TITLE
ESLint: Add and configure import plugin

### DIFF
--- a/packages/eslint-config-humanmade/fixtures/fail/import-order.js
+++ b/packages/eslint-config-humanmade/fixtures/fail/import-order.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-unused-vars */
+
+import apiFetch from '@wordpress/api-fetch';
+import chalk from 'chalk';
+import eslint from 'eslint';
+import path from 'path';
+import './';
+import Test from './component-jsx-parentheses';
+import './style.scss';
+import index from '../../index';
+import '../test-lint-config';

--- a/packages/eslint-config-humanmade/fixtures/pass/import-order.js
+++ b/packages/eslint-config-humanmade/fixtures/pass/import-order.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-unused-vars */
+
+import path from 'path';
+
+import chalk from 'chalk';
+import eslint from 'eslint';
+
+import apiFetch from '@wordpress/api-fetch';
+
+import index from '../../index';
+import '../test-lint-config';
+
+import Test from './component-jsx-parentheses';
+
+import './';
+import './style.scss';

--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -7,6 +7,7 @@ module.exports = {
 	'extends': [
 		'eslint:recommended',
 		'react-app',
+		'plugin:import/errors',
 		'plugin:jsdoc/recommended',
 		'plugin:react-hooks/recommended',
 	],
@@ -40,6 +41,23 @@ module.exports = {
 		'eol-last': [ 'error', 'unix' ],
 		'eqeqeq': [ 'error' ],
 		'func-call-spacing': [ 'error' ],
+		'import/no-unresolved': [ 'off' ],
+		'import/order': [ 'error', {
+			'alphabetize': {
+				'order': 'asc',
+				'caseInsensitive': true
+			},
+			'groups': [ 'builtin', 'external', 'parent', 'sibling', 'index' ],
+			'newlines-between': 'always',
+			'pathGroups': [
+				{
+					'pattern': '@wordpress/**',
+					'group': 'external',
+					'position': 'after'
+				}
+			],
+			'pathGroupsExcludedImportTypes': [ 'builtin' ]
+		} ],
 		'indent': [ 'error', 'tab', {
 			'SwitchCase': 1,
 		} ],


### PR DESCRIPTION
This is a first pass for #84, making use of the already available [ESLint `import` plugin](https://github.com/benmosher/eslint-plugin-import/) (and **not** the [`sort-imports` rule](https://eslint.org/docs/rules/sort-imports)).

I decided to only pull in rules that are considered [errors](https://github.com/benmosher/eslint-plugin-import/blob/master/config/errors.js):
* [`import/default`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md)
* [`import/export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md)
* [`import/named`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md)
* [`import/namespace`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md)
* ~~[`import/no-unresolved`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md)~~

As indicated, I disabled the last rule, `no-unresolved`, as we make use of `externals`, mostly for `@wordpress/**` packages and things such as `react` or `lodash`.
Another way to go about this would be to add exceptions to the `no-unresolved` rule. This is easily possible, but since this might differ, both between various projects, and over time, in general, I thought it best to disable therule.

I also manually added and configured the [`import/order` rule](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md), and, unless I madea mistake, here's how it should expect import statements to occur:

1. Node.JS **built-in** modules such as `path`.
1. Regular **external** packages specified in the `package.json` file.
1. **`@wordpress/**`** packages.
1. Local files in a **parent** folder, 
1. Local **sibling** files, meaning in the current file's folder.
1. A potential _main_ **index.(js|ts)x?** file.

Each block has to be ordered alphabetically, case-insensitive, with regard to the package name and file path, respectively. And there has to be single blank line between any two subsequent blocks from the above list.

I also added two fixture files:

1. **pass:**
```js
/* eslint-disable no-unused-vars */

import path from 'path';

import chalk from 'chalk';
import eslint from 'eslint';

import apiFetch from '@wordpress/api-fetch';

import index from '../../index';
import '../test-lint-config';

import Test from './component-jsx-parentheses';

import './';
import './style.scss';
```

1. **fail:**
```js
/* eslint-disable no-unused-vars */

import apiFetch from '@wordpress/api-fetch';
import chalk from 'chalk';
import eslint from 'eslint';
import path from 'path';
import './';
import Test from './component-jsx-parentheses';
import './style.scss';
import index from '../../index';
import '../test-lint-config';
```

----

**Please** provide some feedback, and maybe even try this out. Thanks! 🙏