### PR TITLE
Support ESLint v6 & v7 in `peerDependencies`

### DIFF
--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -44,7 +44,7 @@
 	},
 	"peerDependencies": {
 		"babel-eslint": "^10.0.0",
-		"eslint": "^5.10.0 || ^6.0.0 || ^7.0.0"
+		"eslint": "^5.10.0 || ^6.0.0 || ^7.0.0",
 		"eslint-config-react-app": "^3.0.5",
 		"eslint-plugin-flowtype": "^3.2.0",
 		"eslint-plugin-import": "^2.14.0",

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -44,7 +44,7 @@
 	},
 	"peerDependencies": {
 		"babel-eslint": "^10.0.0",
-		"eslint": "^5.10.0",
+		"eslint": "^5.10.0 || ^6.0.0 || ^7.0.0"
 		"eslint-config-react-app": "^3.0.5",
 		"eslint-plugin-flowtype": "^3.2.0",
 		"eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
Draft: This is a WIP, adding the multiple ESLint versions to `peerDependencies` may cause issues with the install instructions: `npx install-peerdeps --dev @humanmade/eslint-config@latest` and needs further testing


Right now if installing `@humanmade/eslint-config` v1.0.0 with ESLint v6 or v7 installed the following message is observed:

> `npm WARN @humanmade/eslint-config@1.0.0 requires a peer of eslint@^5.10.0 but none is installed. You must install peer dependencies yourself.`

Adding v6 and v7 to the `peerDependencies` will resolve this

