### PR TITLE
Update the readme to use scoped module name for eslint in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Alternatively, you can create your own configuration and extend these rules:
 `.eslintrc`
 ```json
 {
-  "extends": "humanmade"
+  "extends": "@humanmade"
 }
 ```
 


### PR DESCRIPTION
Got caught out by this - if you don't use the scoped module name it doesn't work (although I think it used to pre-1.0.0)

The readme within the eslint pacakge is actually correct, but this version hasn't reached the [npm page](https://www.npmjs.com/package/@humanmade/eslint-config) which is still not right. 