### PR TITLE
Support 'relation' element in meta query sniff.

### DIFF
--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -136,8 +136,16 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			return;
 		}
 
-		// Otherwise, recurse.
 		foreach ( $elements as $element ) {
+			if ( isset( $element['index_start'] ) ) {
+				$index = $this->strip_quotes( $this->tokens[ $element['index_start'] ]['content'] );
+				if ( strtolower( $index ) === 'relation' ) {
+					// Skip 'relation' element.
+					continue;
+				}
+			}
+
+			// Otherwise, recurse.
 			$this->check_meta_query_item( $element['value_start'] );
 		}
 	}

--- a/tests/fixtures/pass/meta-queries.php
+++ b/tests/fixtures/pass/meta-queries.php
@@ -19,6 +19,44 @@ new WP_Query( [
 	],
 ] );
 
+// Specifying relation is OK.
+new WP_Query( [
+	'meta_query' => [
+		'relation' => 'AND',
+		[
+			'key' => 'foo',
+			'compare' => 'EXISTS',
+		],
+		[
+			'key' => 'bar',
+			'compare' => 'NOT EXISTS',
+		],
+	],
+] );
+new WP_Query( [
+	'meta_query' => [
+		'relation' => 'OR',
+		[
+			'key' => 'foo',
+			'compare' => 'NOT EXISTS',
+		],
+		[
+			'key' => 'bar',
+			'compare' => 'EXISTS',
+		],
+	],
+] );
+$relation = 'OR';
+new WP_Query( [
+	'meta_query' => [
+		'relation' => $relation,
+		[
+			'key' => 'foo',
+			'compare' => 'EXISTS',
+		],
+	],
+] );
+
 // Ignores should work.
 new WP_Query( [
 	'meta_query' => [


### PR DESCRIPTION
The code introduced in #181 breaks for queries that include the `relation` element.

Example:

```
'meta_query' => [
    'relation' => 'OR', // <-- This triggers a false-positive.
    [ ... ],
],
```

The reason is that the current code only expects (nested) arrays inside the meta query element, or a "first-order" query.

This PR adds support for the `relation` element, by skipping over it, if found. Please see also the added fixtures.