### PR TITLE
Update PHP_CodeSniffer Composer Installer package to support Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"squizlabs/php_codesniffer": "~3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"


### PR DESCRIPTION
When using Composer 2, the CI build breaks due to a plugin (API) conflict in the [PHP_CodeSniffer Composer Installer](https://github.com/Dealerdirect/phpcodesniffer-composer-installer) package, as seen [here](https://travis-ci.org/github/humanmade/coding-standards/jobs/738939458#L261).

This PR bumps the dependency to its most recent version, [0.7.0](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0), that comes with support for Composer 2.