### PR TITLE
Backport PHP_CodeSniffer Installer package upgrade to v0.8 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"squizlabs/php_codesniffer": "~3.5.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"


### PR DESCRIPTION
We'll release this as v0.8.1