### PR TITLE
#142 - Add new Isset sniff

### DIFF
--- a/HM/Sniffs/PHP/IssetSniff.php
+++ b/HM/Sniffs/PHP/IssetSniff.php
@@ -23,7 +23,7 @@ class IssetSniff implements Sniff {
 
 		$comma_token = $phpcsFile->findNext( T_COMMA, $open_parenthesis_token + 1 );
 		if ( $comma_token !== false && $comma_token < $tokens[ $open_parenthesis_token ]['parenthesis_closer'] ) {
-			$phpcsFile->addError( 'Only one argument is allowed per ISSET call', $stackPtr, 'MultipleArguments' );
+			$phpcsFile->addWarning( 'Only one argument should be used per ISSET call', $stackPtr, 'MultipleArguments' );
 		}
 	}
 }

--- a/HM/Sniffs/PHP/IssetSniff.php
+++ b/HM/Sniffs/PHP/IssetSniff.php
@@ -1,0 +1,29 @@
+<?php
+namespace HM\Sniffs\PHP;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Sniff to check for isset() usage.
+ */
+class IssetSniff implements Sniff {
+	public function register() {
+		return array( T_ISSET );
+	}
+
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$open_parenthesis_token = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $stackPtr + 1 );
+		if ( $open_parenthesis_token === false ) {
+			throw new RuntimeException( '$stackPtr was not a valid T_ISSET' );
+		}
+
+		$comma_token = $phpcsFile->findNext( T_COMMA, $open_parenthesis_token + 1 );
+		if ( $comma_token !== false && $comma_token < $tokens[ $open_parenthesis_token ]['parenthesis_closer'] ) {
+			$phpcsFile->addError( 'Only one argument is allowed per ISSET call', $stackPtr, 'MultipleArguments' );
+		}
+	}
+}

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -106,6 +106,7 @@ class FixtureTests extends TestCase {
 			'HM.Namespaces.NoLeadingSlashOnUse',
 			'HM.Performance.SlowMetaQuery',
 			'HM.Performance.SlowOrderBy',
+			'HM.PHP.Isset',
 			'HM.Security.EscapeOutput',
 			'HM.Security.NonceVerification',
 			'HM.Security.ValidatedSanitizedInput',

--- a/tests/fixtures/fail/isset.php
+++ b/tests/fixtures/fail/isset.php
@@ -1,0 +1,7 @@
+<?php
+
+isset( $a, $b );
+isset(
+	$a,
+	$b
+);

--- a/tests/fixtures/fail/isset.php.json
+++ b/tests/fixtures/fail/isset.php.json
@@ -1,0 +1,14 @@
+{
+	"3": [
+		{
+			"source": "HM.PHP.Isset.MultipleArguments",
+			"type": "error"
+		}
+	],
+	"4": [
+		{
+			"source": "HM.PHP.Isset.MultipleArguments",
+			"type": "error"
+		}
+	]
+}

--- a/tests/fixtures/fail/isset.php.json
+++ b/tests/fixtures/fail/isset.php.json
@@ -2,13 +2,13 @@
 	"3": [
 		{
 			"source": "HM.PHP.Isset.MultipleArguments",
-			"type": "error"
+			"type": "warning"
 		}
 	],
 	"4": [
 		{
 			"source": "HM.PHP.Isset.MultipleArguments",
-			"type": "error"
+			"type": "warning"
 		}
 	]
 }

--- a/tests/fixtures/pass/isset.php
+++ b/tests/fixtures/pass/isset.php
@@ -1,0 +1,6 @@
+<?php
+
+isset( $a );
+isset(
+	$a
+);


### PR DESCRIPTION
This PR adds a new sniff, `HM.PHP.Isset` that throws an error for `isset` calls with more than one argument, as per request in #142.

I wasn't sure if wanted to make this an error, or just a warning. Looking at existing warnings and errors, I think we are rather inconsistent. Some Layout and opinionated sniffs throw errors, while others just warn about stuff that makes perfect sense to follow.

Thoughts?

Do we want to make this a part of `HM-Minimum`?