### PR TITLE
#154 - Add new Ternary sniff

### DIFF
--- a/HM/Sniffs/PHP/TernarySniff.php
+++ b/HM/Sniffs/PHP/TernarySniff.php
@@ -43,11 +43,11 @@ class TernarySniff implements Sniff {
 		}
 
 		$warning = 'Unnecessary ternary found: Instead of "$expr ? %s : %s", use "%s"';
-		$data = [
+		$data = array(
 			$value_if_true_tokens[0]['content'],
 			$value_if_false_tokens[0]['content'],
 			$value_if_true_tokens[0]['content'] === 'true' ? '(bool) $expr' : '! $expr'
-		];
+		);
 		$phpcsFile->addWarning( $warning, $stackPtr, 'UnnecessaryTernary', $data );
 	}
 
@@ -56,12 +56,12 @@ class TernarySniff implements Sniff {
 
 		return array_values( array_filter(
 			$tokens,
-			[ $this, 'is_nonempty_token' ]
+			array( $this, 'is_nonempty_token' )
 		) );
 	}
 
 	private function is_boolean_token( array $token ) {
-		return in_array( $token['code'], [ T_FALSE, T_TRUE ], true );
+		return in_array( $token['code'], array( T_FALSE, T_TRUE ), true );
 	}
 
 	private function is_nonempty_token( array $token ) {

--- a/HM/Sniffs/PHP/TernarySniff.php
+++ b/HM/Sniffs/PHP/TernarySniff.php
@@ -29,7 +29,7 @@ class TernarySniff implements Sniff {
 			return;
 		}
 
-		$ternary_end_token = $phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_CLOSE_PARENTHESIS, T_SEMICOLON ), $stackPtr + 1 );
+		$ternary_end_token = $phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_CLOSE_PARENTHESIS, T_COMMA, T_SEMICOLON ), $stackPtr + 1 );
 
 		$value_if_false_tokens = $this->get_nonempty_tokens( $tokens, $stackPtr + 1, $ternary_end_token - 1 );
 		if ( count( $value_if_false_tokens ) !== 1 ) {

--- a/HM/Sniffs/PHP/TernarySniff.php
+++ b/HM/Sniffs/PHP/TernarySniff.php
@@ -1,0 +1,70 @@
+<?php
+namespace HM\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Sniff to check for ternary usage.
+ */
+class TernarySniff implements Sniff {
+	public function register() {
+		return array( T_INLINE_ELSE );
+	}
+
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$inline_then_token = $phpcsFile->findPrevious( T_INLINE_THEN, $stackPtr );
+
+		$value_if_true_tokens = $this->get_nonempty_tokens( $tokens, $inline_then_token + 1, $stackPtr - 1 );
+		if ( count( $value_if_true_tokens ) !== 1 ) {
+			// No single value.
+			return;
+		}
+
+		if ( ! $this->is_boolean_token( $value_if_true_tokens[0] ) ) {
+			// No Boolean value.
+			return;
+		}
+
+		$ternary_end_token = $phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_CLOSE_PARENTHESIS, T_SEMICOLON ), $stackPtr + 1 );
+
+		$value_if_false_tokens = $this->get_nonempty_tokens( $tokens, $stackPtr + 1, $ternary_end_token - 1 );
+		if ( count( $value_if_false_tokens ) !== 1 ) {
+			// No single value.
+			return;
+		}
+
+		if ( ! $this->is_boolean_token( $value_if_false_tokens[0] ) ) {
+			// No Boolean value.
+			return;
+		}
+
+		$warning = 'Unnecessary ternary found: Instead of "$expr ? %s : %s", use "%s"';
+		$data = [
+			$value_if_true_tokens[0]['content'],
+			$value_if_false_tokens[0]['content'],
+			$value_if_true_tokens[0]['content'] === 'true' ? '(bool) $expr' : '! $expr'
+		];
+		$phpcsFile->addWarning( $warning, $stackPtr, 'UnnecessaryTernary', $data );
+	}
+
+	private function get_nonempty_tokens( array $tokens, $start, $end ) {
+		$tokens = array_slice( $tokens, $start, $end - $start + 1 );
+
+		return array_values( array_filter(
+			$tokens,
+			[ $this, 'is_nonempty_token' ]
+		) );
+	}
+
+	private function is_boolean_token( array $token ) {
+		return in_array( $token['code'], [ T_FALSE, T_TRUE ], true );
+	}
+
+	private function is_nonempty_token( array $token ) {
+		return ! in_array( $token['code'], Tokens::$emptyTokens, true );
+	}
+}

--- a/tests/FixtureTests.php
+++ b/tests/FixtureTests.php
@@ -106,6 +106,7 @@ class FixtureTests extends TestCase {
 			'HM.Namespaces.NoLeadingSlashOnUse',
 			'HM.Performance.SlowMetaQuery',
 			'HM.Performance.SlowOrderBy',
+			'HM.PHP.Ternary',
 			'HM.Security.EscapeOutput',
 			'HM.Security.NonceVerification',
 			'HM.Security.ValidatedSanitizedInput',

--- a/tests/fixtures/fail/ternary.php
+++ b/tests/fixtures/fail/ternary.php
@@ -1,0 +1,11 @@
+<?php
+
+$result = $expr ? true : false;
+$result = $expr ? false : true;
+$result = ( $expr ? true : false );
+$result = ( $expr ? false : true );
+
+{
+	// Missing semicolon on purpose.
+	return $expr ? true : false
+}

--- a/tests/fixtures/fail/ternary.php
+++ b/tests/fixtures/fail/ternary.php
@@ -9,3 +9,5 @@ $result = ( $expr ? false : true );
 	// Missing semicolon on purpose.
 	return $expr ? true : false
 }
+
+print( $expr ? true : false, 'foo' );

--- a/tests/fixtures/fail/ternary.php.json
+++ b/tests/fixtures/fail/ternary.php.json
@@ -28,5 +28,11 @@
 			"source": "HM.PHP.Ternary.UnnecessaryTernary",
 			"type": "warning"
 		}
+	],
+	"13": [
+		{
+			"source": "HM.PHP.Ternary.UnnecessaryTernary",
+			"type": "warning"
+		}
 	]
 }

--- a/tests/fixtures/fail/ternary.php.json
+++ b/tests/fixtures/fail/ternary.php.json
@@ -1,0 +1,32 @@
+{
+	"3": [
+		{
+			"source": "HM.PHP.Ternary.UnnecessaryTernary",
+			"type": "warning"
+		}
+	],
+	"4": [
+		{
+			"source": "HM.PHP.Ternary.UnnecessaryTernary",
+			"type": "warning"
+		}
+	],
+	"5": [
+		{
+			"source": "HM.PHP.Ternary.UnnecessaryTernary",
+			"type": "warning"
+		}
+	],
+	"6": [
+		{
+			"source": "HM.PHP.Ternary.UnnecessaryTernary",
+			"type": "warning"
+		}
+	],
+	"10": [
+		{
+			"source": "HM.PHP.Ternary.UnnecessaryTernary",
+			"type": "warning"
+		}
+	]
+}

--- a/tests/fixtures/pass/ternary.php
+++ b/tests/fixtures/pass/ternary.php
@@ -1,0 +1,14 @@
+<?php
+
+// Short ternaries.
+$result = $expr ?: true;
+$result = $expr ?: false;
+$result = $expr ? : true;
+$result = $expr ? : false;
+
+// Only one Boolean values.
+$result = $expr ? true : null;
+$result = $expr ? '' : false;
+
+// Nested ternaries. We don't want to do this, but the sniff should not flag this, at least.
+$result = $expr ? true : $other ? false : null;


### PR DESCRIPTION
This PR adds a new sniff, `HM.PHP.Ternary` that adds a warning for unnecessary ternary expression, as mentioned in #154:
* `$expr ? true : false`;
* `$expr ? false : true`.

See fixtures for (passing and failing) example code.

Output is as follows:

```
  3 | WARNING | Unnecessary ternary found: Instead of "$expr ? true : false", use "(bool) $expr"
  4 | WARNING | Unnecessary ternary found: Instead of "$expr ? false : true", use "! $expr"
```

Can anyone think of any edge-case usage that the sniff would either flag as false-positive, or that it would miss?

I'm not 100% sure I considered all tokens that would _end_ the ternary, which currently are: semicolon, closing parenthesis, closing curly brace (function or any other scope), and also comma (which I just added in a subsequent commit).
Anything else?
Maybe @jrfnl? 🙂