### PR TITLE
Retroactively update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.2 (December, 2020)
+## 1.1.2 (December 10, 2020)
 
 ### Removed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 - Disabled requirement to align PHPDoc parameters, inherited from WordPress-Docs in July's 1.0 release #239
 
+## 1.1.1 (October 27, 2020)
+
+### Added:
+
+- Support Composer 2 #233
+
+### Changed:
+
+- Allowed use of the "relation" element in meta query sniff #232
+
 ## 1.1.0 (September 18, 2020)
 
 ### Added:

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"
+	},
+	"scripts": {
+		"test": "phpunit"
 	}
 }


### PR DESCRIPTION
Realized we needed to backfill the 1.1.1 release...

Also fills in the date for 1.1.2 assuming we're releasing that relaxation of phpdoc alignment today, and adds a composer test script alias to make the testing path discoverable via avenues other than contributing.md