### PR TITLE
Use PHIVE to manage PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ yarn.lock
 # Ignore built files
 archives/
 phpcs-standard/
+
+# Ignore tools
+/tools/

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpunit" version="^5.7" installed="5.7.27" location="./tools/phpunit" copy="false"/>
+</phive>

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,7 @@
 		"squizlabs/php_codesniffer": "~3.5.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
-	"require-dev": {
-		"phpunit/phpunit": "^5.7"
-	},
 	"scripts": {
-		"test": "phpunit"
+		"test": "./tools/phpunit"
 	}
 }


### PR DESCRIPTION
This PR introduces [PHIVE](https://github.com/phar-io/phive) to manage PHPUnit. For more information on PHIVE, please refer to the [official](https://phar.io) [website](https://phar.io/how-it-works.html).

Instead of including PHPUnit as a Composer (dev) dependency, we would run `phive install`, and have PHPUnit (symlinked) available at `tools/phpunit` inside our project root.

Not having PHPUnit as a Composer dependency would mean that, in addition to PHPUnit itself, also all these packages are no longer installed:

```
Package operations: 0 installs, 0 updates, 26 removals
  - Removing webmozart/assert (1.9.1)
  - Removing symfony/yaml (v4.4.19)
  - Removing symfony/polyfill-ctype (v1.22.0)
  - Removing sebastian/version (2.0.1)
  - Removing sebastian/resource-operations (1.0.0)
  - Removing sebastian/recursion-context (2.0.0)
  - Removing sebastian/object-enumerator (2.0.1)
  - Removing sebastian/global-state (1.1.1)
  - Removing sebastian/exporter (2.0.0)
  - Removing sebastian/environment (2.0.0)
  - Removing sebastian/diff (1.4.3)
  - Removing sebastian/comparator (1.2.4)
  - Removing sebastian/code-unit-reverse-lookup (1.0.2)
  - Removing phpunit/phpunit-mock-objects (3.4.4)
  - Removing phpunit/phpunit (5.7.27)
  - Removing phpunit/php-token-stream (2.0.2)
  - Removing phpunit/php-timer (1.0.9)
  - Removing phpunit/php-text-template (1.2.1)
  - Removing phpunit/php-file-iterator (1.4.5)
  - Removing phpunit/php-code-coverage (4.0.8)
  - Removing phpspec/prophecy (v1.10.3)
  - Removing phpdocumentor/type-resolver (1.4.0)
  - Removing phpdocumentor/reflection-docblock (5.2.2)
  - Removing phpdocumentor/reflection-common (2.2.0)
  - Removing myclabs/deep-copy (1.10.2)
  - Removing doctrine/instantiator (1.4.0)
```

This means a 11M smaller `vendor` folder (14M vs. 25M).

I'll leave this PR here for discussion. 🤓