### PR TITLE
Remove deprecated/removed PSR-2-R rule

### DIFF
--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -135,7 +135,6 @@
 		<exclude name="PSR2.Namespaces.UseDeclaration.MultipleDeclarations" />
 	</rule>
 	<rule ref="PSR2R.Namespaces.UnusedUseStatement" />
-	<rule ref="PSR2R.Namespaces.UseInAlphabeticalOrder" />
 
 	<!-- Ban inline assignment in control structures (see note on Yoda Conditions above). -->
 	<rule ref="PSR2R.ControlStructures.NoInlineAssignment" />


### PR DESCRIPTION
The `PSR2R.Namespaces.UseInAlphabeticalOrder` rule has been [removed](https://github.com/php-fig-rectified/psr2r-sniffer/commit/3f602977f4eb9cb1c2bfadeef0f0131ee15986fb) from the [PSR-2-R](https://github.com/php-fig-rectified/psr2r-sniffer) standard, so we should remove it, too. As soon as we'd update the standard, it would break anyway. See #245.