### PR TITLE
Migrate to @babel/eslint-parser

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -11,6 +11,10 @@ module.exports = {
 		'plugin:jsdoc/recommended',
 		'plugin:react-hooks/recommended',
 	],
+	'plugins': [
+		'@babel',
+	],
+	'parser': '@babel/eslint-parser',
 	'parserOptions': {
 		'ecmaVersion': 2018,
 		'ecmaFeatures': {

--- a/packages/eslint-config-humanmade/package-lock.json
+++ b/packages/eslint-config-humanmade/package-lock.json
@@ -13,44 +13,42 @@
 				"@babel/highlight": "^7.10.4"
 			}
 		},
-		"@babel/generator": {
-			"version": "7.11.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+		"@babel/eslint-parser": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+			"integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.5",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"eslint-scope": "^5.1.0",
+				"eslint-visitor-keys": "^1.3.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
-		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+		"@babel/eslint-plugin": {
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.13.16.tgz",
+			"integrity": "sha512-RNL0dLHBvjXW857JwzToTHxtbOZfGcvdSegcgXC1c1PqfE+o/QN8MugkgKj2vXFxCcMByfxJrmpCbLzVBVlgIA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.11.0"
+				"eslint-rule-composer": "^0.3.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -70,12 +68,6 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
-		"@babel/parser": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
-			"dev": true
-		},
 		"@babel/runtime": {
 			"version": "7.11.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
@@ -93,45 +85,6 @@
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.11.5",
-				"@babel/types": "^7.11.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
-			}
-		},
-		"@babel/types": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@types/json5": {
@@ -259,20 +212,6 @@
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
 			"integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
 			"dev": true
-		},
-		"babel-eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -735,6 +674,12 @@
 				"natural-compare-lite": "^1.4.0"
 			}
 		},
+		"eslint-rule-composer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+			"integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+			"dev": true
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -1149,12 +1094,6 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-8.0.0.tgz",
 			"integrity": "sha512-eLCs6s4JqN8TjFJfgdiLHRvogLhOAJz+5RIA2FtoMe6ZDyuvghvppnlIToqAEnVbxRqLMrfnNXpW8FpmR6IMBw==",
-			"dev": true
-		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -1752,12 +1691,6 @@
 				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
-		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
-		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -1930,12 +1863,6 @@
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
 		},
 		"tsconfig-paths": {
 			"version": "3.9.0",

--- a/packages/eslint-config-humanmade/package.json
+++ b/packages/eslint-config-humanmade/package.json
@@ -30,7 +30,8 @@
 		"index.js"
 	],
 	"devDependencies": {
-		"babel-eslint": "^10.0.0",
+		"@babel/eslint-parser": "^7.13.14",
+		"@babel/eslint-plugin": "^7.13.16",
 		"chalk": "^2.4.1",
 		"eslint": "^5.10.0",
 		"eslint-config-react-app": "^3.0.5",
@@ -59,5 +60,6 @@
 	},
 	"scripts": {
 		"test": "node fixtures/test-lint-config"
-	}
+	},
+	"dependencies": {}
 }


### PR DESCRIPTION
I ran into an issue with eslint which led me to the solution - which is to use `@babel/eslint-parser` instead of `babel-eslint` which is deprecated.
Note that I had to also set `BABEL_ENV = development` in the script command
https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint

This fixes the issue when I run the linter locally, but the linter bot fails because our library doesn't have `@babel/eslint-parser` and `@babel/eslint-plugin`

@kadamwhite how could I test this to make it more likely to get merged without breaking anything?