### PR TITLE
Update custom escaping functions for clean_html

### DIFF
--- a/HM-Minimum/ruleset.xml
+++ b/HM-Minimum/ruleset.xml
@@ -29,6 +29,7 @@
 		<properties>
 			<property name="customEscapingFunctions" type="array">
 				<element value="whitelist_html" />
+				<element value="clean_html" />
 			</property>
 			<property name="customAutoEscapedFunctions" type="array">
 				<!-- Allow all the built-in URL functions -->


### PR DESCRIPTION
We renamed the clean_html function from whitelist_html in https://github.com/humanmade/clean-html/issues/6 but didn't update the standards to reflect.