### PR TITLE
Remove deprecated "declaration-property-" rules

### DIFF
--- a/packages/stylelint-config/.stylelintrc.json
+++ b/packages/stylelint-config/.stylelintrc.json
@@ -14,10 +14,10 @@
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-block-single-line-max-declarations": 4,
     "declaration-no-important": true,
-    "declaration-property-unit-blacklist": {
+    "declaration-property-unit-disallowed-list": {
       "font-size": [ "px" ]
     },
-    "declaration-property-unit-whitelist": {
+    "declaration-property-unit-allowed-list": {
       "animation": [ "ms" ],
       "animation-delay": [ "ms" ],
       "animation-duration": [ "ms" ],


### PR DESCRIPTION
Both `declaration-property-unit-blacklist` and `declaration-property-unit-whitelist` have been deprecated. The current
ruleset will still run, it will throw deprecation warnings about these two rules. This updates them.

- https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-unit-blacklist/README.md
- https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-unit-whitelist/README.md