### PR TITLE
Ignore "use" within "class" in OrderSniff

### DIFF
--- a/HM/Sniffs/Layout/OrderSniff.php
+++ b/HM/Sniffs/Layout/OrderSniff.php
@@ -51,6 +51,9 @@ class OrderSniff implements Sniff {
 			if ( $next_token['code'] === T_USE && $phpcsFile->findPrevious( T_CLOSURE, $next_pos, null, false, null, true ) !== false ) {
 				continue;
 			}
+			if ( $next_token['code'] === T_USE && $phpcsFile->findPrevious( T_CLASS, $next_pos, null, false, null, true ) !== false ) {
+				continue;
+			}
 
 			// Must be current or higher.
 			$next_type_score = $look_for[ $next_token['code'] ];

--- a/tests/fixtures/pass/use-order.php
+++ b/tests/fixtures/pass/use-order.php
@@ -2,6 +2,7 @@
 
 use Foo\Bar;
 use Foo\Baz as Zztop;
+use Some_Trait;
 
 require( 'some/file/that/exists.php' );
 
@@ -42,3 +43,7 @@ add_action( 'init', function () use ( $foo ) {
 $c = function() {
 	return true;
 };
+
+class My_Class {
+	use Some_Trait;
+}


### PR DESCRIPTION
The error which is reported:

    (
    	[message] => use found on line 48, but require was declared on line 7. Statements should be ordered `namespace`, `use`, `const`, `require`, then code.
    	[source] => HM.Layout.Order.WrongOrder
    	[listener] => HM\Sniffs\Layout\OrderSniff
    	[severity] => 5
    	[fixable] =>
    )

It should be possible to `use` a trait within a class, without triggering the warning for a top-level namespace `use` statement.