### PR TITLE
Update PHPCS to support PHP 8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,18 @@ jobs:
         - composer install
       script:
         - vendor/bin/phpunit
+    - language: php
+      php: 8.0
+      install:
+        - composer install
+      script:
+        - vendor/bin/phpunit
+    - language: php
+      php: 8.1
+      install:
+        - composer install
+      script:
+        - vendor/bin/phpunit
     - language: node_js
       node_js: 10
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,16 @@ jobs:
     - language: php
       php: 8.0
       install:
-        - composer install
+        - composer install --ignore-platform-reqs
       script:
         - vendor/bin/phpunit
     - language: php
       php: 8.1
       install:
-        - composer install
+        - composer install --ignore-platform-reqs
       script:
-        - vendor/bin/phpunit
+        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/FixtureTests.php
+        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/AllSniffs.php
     - language: node_js
       node_js: 10
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,20 @@ jobs:
     - language: php
       php: 8.0
       install:
+        # For PHP 8.0+, we need to ignore platform reqs as PHPUnit 7 is still used.
         - composer install --ignore-platform-reqs
       script:
         - vendor/bin/phpunit
     - language: php
       php: 8.1
       install:
+        # For PHP 8.0+, we need to ignore platform reqs as PHPUnit 7 is still used.
         - composer install --ignore-platform-reqs
       script:
-        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/FixtureTests.php
+        # For PHP 8.1+, we need to ignore the config file so that PHPUnit 7 doesn't try to read it and cause an error.
+        # Instead, we pass all required settings as part of the phpunit command.
         - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/AllSniffs.php
+        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/FixtureTests.php
     - language: node_js
       node_js: 10
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ jobs:
       script:
         # For PHP 8.1+, we need to ignore the config file so that PHPUnit 7 doesn't try to read it and cause an error.
         # Instead, we pass all required settings as part of the phpunit command.
-        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/AllSniffs.php
-        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php tests/FixtureTests.php
+        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests tests/AllSniffs.php
+        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests tests/FixtureTests.php
     - language: node_js
       node_js: 10
       install:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.1",
-		"wp-coding-standards/wpcs": "2.2.1",
+		"wp-coding-standards/wpcs": "2.3.0",
 		"automattic/vipwpcs": "2.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"automattic/vipwpcs": "2.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
-		"squizlabs/php_codesniffer": "~3.5.0",
+		"squizlabs/php_codesniffer": "~3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
 	},
 	"scripts": {
 		"test": "phpunit"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7"
+		"phpunit/phpunit": "^7"
 	},
 	"scripts": {
 		"test": "phpunit"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,5 @@
 <phpunit
+	beStrictAboutTestsThatDoNotTestAnything="false"
 	bootstrap="tests/bootstrap.php"
 	colors="true"
 	convertErrorsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
 >
 	<testsuites>
 		<!-- Default test suite to run all tests -->
-		<testsuite>
+		<testsuite name="all">
 			<file>tests/AllSniffs.php</file>
 			<file>tests/FixtureTests.php</file>
 		</testsuite>

--- a/tests/AllSniffs.php
+++ b/tests/AllSniffs.php
@@ -42,6 +42,7 @@ class AllSniffs {
 	public static function suite() {
 		$GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']   = array();
 		$GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'] = array();
+		$GLOBALS['PHP_CODESNIFFER_SNIFF_CASE_FILES'] = array();
 
 		$suite = new TestSuite( 'HM Standards' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,8 +6,8 @@ define( 'PHP_CODESNIFFER_CBF', false );
 
 // Check phpcs is installed.
 $phpcs_dir = dirname( __DIR__ ) . '/vendor/squizlabs/php_codesniffer';
-if ( ! file_exists($phpcs_dir)) {
-	throw new Exception( 'Could not find PHP_CodeSniffer. Run `composer install --prefer-source --dev`' );
+if ( ! file_exists( $phpcs_dir ) ) {
+	throw new Exception( 'Could not find PHP_CodeSniffer. Run `composer install --prefer-source`' );
 }
 
 // Check phpcs' test framework is available.


### PR DESCRIPTION
This change means later versions of PHPCS 3.x can be used, rather than just 3.5. Version 3.7 is required for the sniffs to run on PHP 8.1 without triggering deprecated warnings.

In addition version 3.6 added support for PHP 8 languages features, and 3.7 added support for 8.1 language features.

WPCS and PHPUnit both need to be updated so the tests run on later PHP versions without errors. PHPUnit 7 needs to be used because the base test class in PHPCS that's used for the tests in this library doesn't support PHPUnit 8 ([info here](https://github.com/squizlabs/PHP_CodeSniffer/issues/3490)), hence the use of the ` --ignore-platform-reqs` and `--no-configuration` flags when installing and running the tests on PHP 8 and 8.1.

Todo:

* [x] Determine why the `tests/AllSniffs.php` tests are performing no assertions under PHPUnit 7