### PR TITLE
Add `dealerdirect/phpcodesniffer-composer-installer` to `allow-plugins` in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
 	},
 	"scripts": {
 		"test": "phpunit"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
This resolves an issue with Travis CI where the `dealerdirect/phpcodesniffer-composer-installer` package is blocked from installing because its not included in the `allow-plugins` config and the PHP jobs in Travis CI are failing

<img width="653" alt="image" src="https://user-images.githubusercontent.com/1016458/177910429-8ad7f686-04d7-4268-b2b3-19981d41d40a.png">

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/1016458/177910479-e003b579-83a7-4c42-9e5e-02e1fe8597f3.png">

