### PR TITLE
Remove package.json lint rule for no devdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 					"requireEndingPeriod": true
 				}
 			],
-			"prefer-no-devDependencies": "warning",
 			"require-publishConfig": "error",
 			"require-repository-directory": "error",
 			"valid-values-author": [
@@ -60,8 +59,7 @@
 				],
 				"rules": {
 					"require-publishConfig": "off",
-					"require-repository-directory": "off",
-					"prefer-no-devDependencies": "off"
+					"require-repository-directory": "off"
 				}
 			}
 		]


### PR DESCRIPTION
We are using `npm-package-json-lint` to check that our package.json files comply with certain rules. 

One of these rules is configured so that you are not allowed to use `devDependencies` in the packages, but it's OK at the top-level. However this test fails because we have devDependencies in the eslint config package. 

Seems to me that we should just disable this rule. I'm not sure why it has ever passed TBH. 