### PR TITLE
Require double quotes for props in JSX

### DIFF
--- a/packages/eslint-config-humanmade/index.js
+++ b/packages/eslint-config-humanmade/index.js
@@ -146,5 +146,6 @@ module.exports = {
 			'ignoreCase': true,
 		} ],
 		'jsx-a11y/anchor-is-valid': [ 'error' ],
+		'jsx-quotes': [ 'error', 'prefer-double' ],
 	},
 };


### PR DESCRIPTION
I recently had use inconsistent use of double/single quotes for props in JSX flagged in a pull request and was surprised this wasn't enforced in our coding standards. 

Thoughts on adding this?