### PR TITLE
Update composer.json to use PHPCS standards package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"automattic/vipwpcs": "2.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
-		"squizlabs/php_codesniffer": "~3.5",
+		"phpcsstandards/php_codesniffer": "~3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Removes the abandoned squizlabs PHPCS package and replaces it with the new PHPCS Standards org version