### PR TITLE
Configure PHP minimum version to 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,6 @@ branches:
 jobs:
   include:
     - language: php
-      php: 8.1
-      install:
-        # For PHP 8.0+, we need to ignore platform reqs as PHPUnit 7 is still used.
-        - composer install --ignore-platform-reqs
-      script:
-        # For PHP 8.1+, we need to ignore the config file so that PHPUnit 7 doesn't try to read it and cause an error.
-        # Instead, we pass all required settings as part of the phpunit command.
-        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests tests/AllSniffs.php
-        - vendor/bin/phpunit --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests tests/FixtureTests.php
-
-    - language: php
       php: 8.2
       install:
         # For PHP 8.0+, we need to ignore platform reqs as PHPUnit 7 is still used.

--- a/HM-Minimum/ruleset.xml
+++ b/HM-Minimum/ruleset.xml
@@ -9,6 +9,8 @@
 
 	<autoload>../HM/bootstrap.php</autoload>
 
+	<config name="testVersion" value="8.2-"/>
+
 	<!-- Check for PHP cross-version compatibility. -->
 	<rule ref="PHPCompatibilityWP">
 		<exclude name="PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound" />

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -12,6 +12,8 @@
 	<!-- Include everything from the minimum set -->
 	<rule ref="HM-Minimum" />
 
+	<config name="testVersion" value="8.2-"/>
+
 	<!-- Check for PHP cross-version compatibility. -->
 	<rule ref="PHPCompatibilityWP" />
 


### PR DESCRIPTION
Fix error relating to our deprecation of all PHP before 8.2 in release 2.0.0

```
1 | ERROR | An error occurred during processing; checking has been aborted. The error     
  message was: trim(): Passing null to parameter #1                                                                        
     |       | ($string) of type string is deprecated in                                                                   
     |       | ..../vendor/phpcompatibility/php-compatibility/PHPCompatibility/Sniff.php 
   on line 131                                                                                                             
     |       | The error originated in the .PHPCompatibility. sniff on line 131.
```

Removes PHP 8.1 from test matrix and configures tooling accordingly so that using the repo passes tests.