### PR TITLE
Fix NamespaceDirectoryNameSniff misreading strict_types as namespace name

### DIFF
--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -30,7 +30,7 @@ class NamespaceDirectoryNameSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$namespace = '';
 
-		$name_ptr = $phpcsFile->findNext( T_STRING, 0);
+		$name_ptr = $phpcsFile->findNext( T_STRING, $stackPtr );
 		if ( ! $name_ptr ) {
 			// Non-namespaced, skip check.
 			return;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
@@ -51,6 +51,7 @@ class NamespaceDirectoryNameUnitTest extends AbstractSniffUnitTest {
 			'namespace.php',
 			'camelcased-namespace.php',
 			'underscored-namespace.php',
+			'strict-types-namespace.php',
 		];
 		if ( in_array( $file, $pass, true ) ) {
 			return [];

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/strict-types-namespace.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/strict-types-namespace.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HM\Coding\Standards\StrictTypesNamespace;


### PR DESCRIPTION
## Summary

Fixes #319.

`NamespaceDirectoryNameSniff` calls `findNext( T_STRING, 0 )` on line 33 to locate the namespace name, which starts searching from position 0 of the file. When the file opens with a `declare(strict_types=1);` statement before its namespace declaration, the first `T_STRING` token in the file is `strict_types` (PHP's tokenizer emits the declare directive name as `T_STRING`), so the sniff reads `strict_types` as the namespace and reports a false `NameMismatch` or `ExtraDirs` error against the actual directory.

## Fix

Change the `findNext` start position from `0` to `$stackPtr`, so the search begins at the `T_NAMESPACE` token the sniff is currently processing rather than the beginning of the file.

```diff
-		$name_ptr = $phpcsFile->findNext( T_STRING, 0);
+		$name_ptr = $phpcsFile->findNext( T_STRING, $stackPtr );
```

This matches the resolution proposed in #319 directly.

## Why this is safe

The fix produces the same result as the existing code in every case except the buggy one:

- **Plain `<?php namespace Foo;`** (no `declare`): the first `T_STRING` in the file is the namespace name itself, so the original (`from position 0`) and the fix (`from $stackPtr`) land on the same token.
- **`<?php declare(strict_types=1); namespace Foo;`**: original reads `strict_types`; fix correctly reads `Foo`.
- **Multi-namespace `namespace A {} namespace B {}` files**: original reads `A` for both invocations (the file-first `T_STRING`); fix correctly reads each block's own namespace name.

Only `declare()` directives can legally place a `T_STRING` token before `T_NAMESPACE`; PHP requires `namespace` to be the first non-declare statement, so other cases aren't reachable in real code.

## Test

Adds `HM/Tests/Files/NamespaceDirectoryNameUnitTest/inc/standards/strict-types-namespace.php` to the existing fixture tree and adds its basename to the `$pass` list in `NamespaceDirectoryNameUnitTest::getErrorList()`. The fixture is the minimal repro from the issue:

```php
<?php

declare(strict_types=1);

namespace HM\Coding\Standards\StrictTypesNamespace;
```

Verified locally with `./vendor/bin/phpunit --filter NamespaceDirectoryNameUnitTest`:

- Without the sniff fix, the new fixture fails: `Expected 0 error(s) in strict-types-namespace.php but found 1 error(s). Directory /standards for namespace strict_types found; nested too deep. (HM.Files.NamespaceDirectoryName.ExtraDirs)`
- With the sniff fix, the full `NamespaceDirectoryNameUnitTest` passes.