### PR TITLE
Relax WPCS version constraint to ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,10 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"wp-coding-standards/wpcs": "~3.0.0",
-		"automattic/vipwpcs": "~3.0.0",
+		"wp-coding-standards/wpcs": "^3.0.0",
+		"automattic/vipwpcs": "^3.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
-		"squizlabs/php_codesniffer": "~3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
+		"squizlabs/php_codesniffer": "^3.13.4",
 		"wp-coding-standards/wpcs": "^3.0.0",
 		"automattic/vipwpcs": "^3.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"squizlabs/php_codesniffer": "^3.13.4",
-		"wp-coding-standards/wpcs": "^3.0.0",
 		"automattic/vipwpcs": "^3.0.0",
+		"wp-coding-standards/wpcs": "^3.0.0",
 		"fig-r/psr2r-sniffer": "^0.5.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
+		"squizlabs/php_codesniffer": "^3.13.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
PHPCS will be pulled in as a transient dependency of both WPCS and VIPCS, so keeping it in our own composer.json does nothing but increase our maintenance burden.

The progressive point updates to WPCS in 3.1, 3.2 and 3.3 have improvements which would benefit HM projects and which make the coding standards more intuitively support modern versions of WordPress.