### PR TITLE
Fix false-positive escaping warning on get_block_wrapper_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next Patch
+
+- Do not flag get_block_wrapper_attributes as an escaping risk, this is a false positive as function escapes internally #340
+
 ## 2.2.0 (June 22, 2026)
 
 - Adds official support for single-file must-use plugins when appropriate by relaxing side-effect and file name restrictions on direct children of mu-plugins/ and client-mu-plugins/ #337

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next Patch
+<!-- Next -->
 
 - Do not flag get_block_wrapper_attributes as an escaping risk, this is a false positive as function escapes internally #340
 

--- a/HM-Minimum/ruleset.xml
+++ b/HM-Minimum/ruleset.xml
@@ -71,6 +71,7 @@
 				<element value="paginate_links" />
 				<element value="get_the_title" />
 				<element value="get_post_gallery" /> <!-- with param 2 set to true, the default -->
+				<element value="get_block_wrapper_attributes" /> <!-- uses safecss_filter_attr and esc_attr internally -->
 			</property>
 		</properties>
 


### PR DESCRIPTION
[get_block_wrapper_attributes](https://github.com/WordPress/WordPress/blob/7.0-branch/wp-includes/class-wp-block-supports.php#L166-L240) responsibly builds its output string using safecss_filter_attr and esc_attr, and its output is not filterable. We should allow this function.

(This is particularly annoying to get false-flagged today, because it usually occurs within an inline <?php ... ?> tag in HTML partials that makes it visually clunky to add an ignore directive.)