### PR TITLE
Exclude built code folders from stylistic PHPCS rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and fill in the contents as you go. This simplifies later release management. --
 
 ## 2.3.0
 
-- Exempt wp-scripts-generated `*.asset.php` manifests under `build/` and `dist/` from stylistic sniffs
+- Do not lint PHP within `build/` and `dist/` build directories
 
 ## 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and fill in the contents as you go. This simplifies later release management. --
 
 ## 2.3.0
 
-- Exempt wp-scripts-generated `*.asset.php` manifests under `build/` and `dist/` from the file-name and file-doc-comment rules
+- Exempt wp-scripts-generated `*.asset.php` manifests under `build/` and `dist/` from stylistic sniffs
 
 ## 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- When submitting a PR for a feature, add the appropriate prerelease heading here
 and fill in the contents as you go. This simplifies later release management. -->
 
+## 2.3.0
+
+- Exempt wp-scripts-generated `*.asset.php` manifests under `build/` and `dist/` from the file-name and file-doc-comment rules
+
 ## 2.2.1
 
 - Do not flag get_block_wrapper_attributes as an escaping risk, this is a false positive as function escapes internally #340

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -4,6 +4,8 @@
 
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
+	<!-- Exempt wp-scripts-generated asset manifests from stylistic rules. -->
+	<exclude-pattern>*/(build|dist)/*\.asset\.php$</exclude-pattern>
 
 	<arg name="extensions" value="php" />
 
@@ -106,14 +108,6 @@
 		<properties>
 			<property name="is_theme" value="true" />
 		</properties>
-	</rule>
-
-	<!-- Exempt wp-scripts-generated asset manifests from unnecessary rules. -->
-	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
-		<exclude-pattern>*/(build|dist)/*\.asset\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>*/(build|dist)/*\.asset\.php$</exclude-pattern>
 	</rule>
 
 	<!--

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -4,8 +4,9 @@
 
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
-	<!-- Exempt wp-scripts-generated asset manifests from stylistic rules. -->
-	<exclude-pattern>*/(build|dist)/*\.asset\.php$</exclude-pattern>
+	<!-- Exempt common build directories from stylistic rules. -->
+	<exclude-pattern>build/*</exclude-pattern>
+	<exclude-pattern>dist/*</exclude-pattern>
 
 	<arg name="extensions" value="php" />
 

--- a/HM/ruleset.xml
+++ b/HM/ruleset.xml
@@ -108,6 +108,14 @@
 		</properties>
 	</rule>
 
+	<!-- Exempt wp-scripts-generated asset manifests from unnecessary rules. -->
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>*/(build|dist)/*\.asset\.php$</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>*/(build|dist)/*\.asset\.php$</exclude-pattern>
+	</rule>
+
 	<!--
 	Restore the ability to have multiple arguments per line
 


### PR DESCRIPTION
Built asset files are standard under current wp-scripts best practices, so our ruleset should not enforce human-authorship-oriented sniffs on these autogenerated files.

I've limited our exclusions to the default `build/` and oft-used `dist/` folder prefixes.