### PR TITLE
Allow namespaces in plugin entrypoints named after the plugin

### DIFF
--- a/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
+++ b/HM/Sniffs/Files/NamespaceDirectoryNameSniff.php
@@ -62,6 +62,13 @@ class NamespaceDirectoryNameSniff implements Sniff {
 			return;
 		}
 
+		if ( in_array( basename( dirname( $directory ) ), [ 'plugins', 'client-mu-plugins', 'mu-plugins' ], true ) ) {
+			if ( pathinfo( $filename, PATHINFO_FILENAME ) === basename( $directory ) ) {
+				// Allow plugin entrypoints named `plugin-name/plugin-name.php` instead of `plugin.php`.
+				return;
+			}
+		}
+
 		if ( ! preg_match( '#(?:.*)(?:/inc|/tests)(/.*)?#', $directory, $matches ) ) {
 			$error = 'Namespaced classes and functions should live inside an inc directory.';
 			$phpcsFile->addError( $error, $stackPtr, 'NoIncDirectory' );

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest.php
@@ -55,6 +55,9 @@ class NamespaceDirectoryNameUnitTest extends AbstractSniffUnitTest {
 			// Single-file mu-plugins are exempt from the directory structure rules.
 			'mu-plugin.php',
 			'client-mu-plugin.php',
+			// Plugin entrypoints should also allow namespace declarations.
+			'mypluginname.php',
+			'plugin.php',
 		];
 		if ( in_array( $file, $pass, true ) ) {
 			return [];

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/plugins/mypluginname/improperly-named.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/plugins/mypluginname/improperly-named.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\My_Plugin_Name;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/plugins/mypluginname/mypluginname.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/plugins/mypluginname/mypluginname.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\My_Plugin_Name;

--- a/HM/Tests/Files/NamespaceDirectoryNameUnitTest/plugins/mypluginname/plugin.php
+++ b/HM/Tests/Files/NamespaceDirectoryNameUnitTest/plugins/mypluginname/plugin.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace HM\Coding\Standards\My_Plugin_Name;


### PR DESCRIPTION
This expands the existing exceptions for "main files" (functions.php, plugin.php) to be able to recognize plugin entrypoints named after the plugin itself, e.g. [query-monitor/query-monitor.php](https://github.com/johnbillion/query-monitor/blob/develop/query-monitor.php) instead of `plugin.php`.

Supersedes #343 